### PR TITLE
fix: google oauth login

### DIFF
--- a/noweekend-core/core-api/src/main/kotlin/noweekend/core/api/config/SecurityConfig.kt
+++ b/noweekend-core/core-api/src/main/kotlin/noweekend/core/api/config/SecurityConfig.kt
@@ -28,6 +28,7 @@ class SecurityConfig {
             "/health",
             "/swagger-ui/**",
             "/v3/api-docs/**",
+            "/api/v1/login/**",
         ),
         "deny" to arrayOf(),
     )
@@ -39,6 +40,7 @@ class SecurityConfig {
             "/health",
             "/swagger-ui/**",
             "/v3/api-docs/**",
+            "/api/v1/login/**",
         ),
         "deny" to arrayOf(
             "/example",

--- a/noweekend-core/core-domain/build.gradle.kts
+++ b/noweekend-core/core-domain/build.gradle.kts
@@ -8,6 +8,8 @@ dependencies {
 
     // JWT
     implementation("io.jsonwebtoken:jjwt-api:0.11.5")
+    runtimeOnly("io.jsonwebtoken:jjwt-impl:0.11.5")
+    runtimeOnly("io.jsonwebtoken:jjwt-jackson:0.11.5")
 
     // jasypt
     implementation("com.github.ulisesbocchio:jasypt-spring-boot-starter:3.0.5")

--- a/noweekend-core/core-domain/src/main/kotlin/noweekend/core/domain/user/UserRepository.kt
+++ b/noweekend-core/core-domain/src/main/kotlin/noweekend/core/domain/user/UserRepository.kt
@@ -2,7 +2,7 @@ package noweekend.core.domain.user
 
 interface UserRepository {
     fun findUserById(id: String): User
-    fun findUserByProviderAndEmail(providerType: ProviderType, email: String): User
+    fun findUserByProviderAndEmail(providerType: ProviderType, email: String): User?
     fun append(id: String, name: String, providerType: ProviderType, role: Role): String
     fun modify(id: String, name: String, role: Role): String
     fun upsert(id: String, name: String, providerType: ProviderType, role: Role): String

--- a/noweekend-storage/db-core/src/main/kotlin/noweekend/storage/db/core/user/UserCoreRepository.kt
+++ b/noweekend-storage/db-core/src/main/kotlin/noweekend/storage/db/core/user/UserCoreRepository.kt
@@ -17,9 +17,9 @@ class UserCoreRepository(
             .toUser()
     }
 
-    override fun findUserByProviderAndEmail(providerType: ProviderType, email: String): User {
+    override fun findUserByProviderAndEmail(providerType: ProviderType, email: String): User? {
         val userEntity = queryDslRepository.findUserByProviderAndEmail(providerType, email)
-            ?: throw NoSuchElementException("User not found: $providerType, $email")
+            ?: return null
         return userEntity.toUser()
     }
 


### PR DESCRIPTION
## 요약(개요)

## 작업 내용
[//]: # (업무 체크리스트를 작성해주세요.)
- [x] login path를 security public에 추가했습니다.
- [x] emailAndProvider 로 조회시 없도록 null 및 safe 하게 처리하여 반환합니다.

## 집중해서 리뷰해야 하는 부분

## 기타 전달 사항 및 참고 자료(선택)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **버그 수정**
  - 로그인 API 경로가 인증 없이 접근 가능하도록 허용되었습니다.
  - 사용자를 제공자와 이메일로 조회할 때, 존재하지 않는 경우 예외 대신 null을 반환하도록 변경되었습니다.

- **기타**
  - JWT 라이브러리 관련 런타임 의존성이 추가되었습니다.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->