### PR TITLE
feat: add argument resolver can get current user id

### DIFF
--- a/noweekend-core/core-api/src/main/kotlin/noweekend/core/api/config/WebConfig.kt
+++ b/noweekend-core/core-api/src/main/kotlin/noweekend/core/api/config/WebConfig.kt
@@ -1,0 +1,14 @@
+package noweekend.core.api.config
+
+import noweekend.core.api.security.annotations.CurrentUserIdArgumentResolver
+import org.springframework.context.annotation.Configuration
+import org.springframework.web.method.support.HandlerMethodArgumentResolver
+import org.springframework.web.servlet.config.annotation.WebMvcConfigurer
+
+@Configuration
+class WebConfig : WebMvcConfigurer {
+
+    override fun addArgumentResolvers(resolvers: MutableList<HandlerMethodArgumentResolver>) {
+        resolvers.add(CurrentUserIdArgumentResolver())
+    }
+}

--- a/noweekend-core/core-api/src/main/kotlin/noweekend/core/api/controller/ApiControllerAdvice.kt
+++ b/noweekend-core/core-api/src/main/kotlin/noweekend/core/api/controller/ApiControllerAdvice.kt
@@ -21,7 +21,7 @@ class ApiControllerAdvice {
             LogLevel.WARN -> log.warn("CoreException : {}", e.message, e)
             else -> log.info("CoreException : {}", e.message, e)
         }
-        return ResponseEntity(ApiResponse.error(e.errorType, e.data), e.errorType.status)
+        return ResponseEntity(ApiResponse.error(e.errorType, e.message, e.data), e.errorType.status)
     }
 
     @ExceptionHandler(Exception::class)

--- a/noweekend-core/core-api/src/main/kotlin/noweekend/core/api/security/annotations/CurrentUserId.kt
+++ b/noweekend-core/core-api/src/main/kotlin/noweekend/core/api/security/annotations/CurrentUserId.kt
@@ -1,0 +1,37 @@
+package noweekend.core.api.security.annotations
+
+import noweekend.core.support.error.InvalidTokenException
+import org.springframework.core.MethodParameter
+import org.springframework.security.core.Authentication
+import org.springframework.security.core.context.SecurityContextHolder
+import org.springframework.web.bind.support.WebDataBinderFactory
+import org.springframework.web.context.request.NativeWebRequest
+import org.springframework.web.method.support.HandlerMethodArgumentResolver
+import org.springframework.web.method.support.ModelAndViewContainer
+
+@Target(AnnotationTarget.VALUE_PARAMETER)
+@Retention(AnnotationRetention.RUNTIME)
+@MustBeDocumented
+annotation class CurrentUserId
+
+class CurrentUserIdArgumentResolver : HandlerMethodArgumentResolver {
+    override fun supportsParameter(parameter: MethodParameter): Boolean {
+        return parameter.getParameterAnnotation(CurrentUserId::class.java) != null &&
+            parameter.parameterType == String::class.java
+    }
+
+    override fun resolveArgument(
+        parameter: MethodParameter,
+        mavContainer: ModelAndViewContainer?,
+        webRequest: NativeWebRequest,
+        binderFactory: WebDataBinderFactory?,
+    ): String {
+        val authentication: Authentication? = SecurityContextHolder.getContext().authentication
+
+        if (authentication == null || !authentication.isAuthenticated) {
+            throw InvalidTokenException("don't find authentication")
+        }
+
+        return authentication.principal.toString()
+    }
+}

--- a/noweekend-core/core-api/src/main/kotlin/noweekend/core/support/error/CoreException.kt
+++ b/noweekend-core/core-api/src/main/kotlin/noweekend/core/support/error/CoreException.kt
@@ -1,6 +1,7 @@
 package noweekend.core.support.error
 
-class CoreException(
+open class CoreException(
     val errorType: ErrorType,
     val data: Any? = null,
-) : RuntimeException(errorType.message)
+    errorMessage: String? = null,
+) : RuntimeException(errorMessage ?: errorType.message)

--- a/noweekend-core/core-api/src/main/kotlin/noweekend/core/support/error/ErrorMessage.kt
+++ b/noweekend-core/core-api/src/main/kotlin/noweekend/core/support/error/ErrorMessage.kt
@@ -10,4 +10,10 @@ data class ErrorMessage private constructor(
         message = errorType.message,
         data = data,
     )
+
+    constructor(errorType: ErrorType, errorMessage: String? = null, data: Any? = null) : this(
+        code = errorType.code.name,
+        message = errorMessage ?: errorType.message,
+        data = data,
+    )
 }

--- a/noweekend-core/core-api/src/main/kotlin/noweekend/core/support/error/InvalidTokenException.kt
+++ b/noweekend-core/core-api/src/main/kotlin/noweekend/core/support/error/InvalidTokenException.kt
@@ -1,0 +1,5 @@
+package noweekend.core.support.error
+
+class InvalidTokenException(
+    errorMessage: String? = null,
+) : CoreException(errorType = ErrorType.UNAUTHORIZED, errorMessage = errorMessage)

--- a/noweekend-core/core-api/src/main/kotlin/noweekend/core/support/response/ApiResponse.kt
+++ b/noweekend-core/core-api/src/main/kotlin/noweekend/core/support/response/ApiResponse.kt
@@ -17,8 +17,12 @@ data class ApiResponse<T> private constructor(
             return ApiResponse(ResultType.SUCCESS, data, null)
         }
 
-        fun <S> error(error: ErrorType, errorData: Any? = null): ApiResponse<S> {
-            return ApiResponse(ResultType.ERROR, null, ErrorMessage(error, errorData))
+        fun <S> error(error: ErrorType, errorMessage: String? = null, errorData: Any? = null): ApiResponse<S> {
+            return ApiResponse(
+                result = ResultType.ERROR,
+                data = null,
+                error = ErrorMessage(error, errorMessage ?: error.message, errorData),
+            )
         }
     }
 }

--- a/noweekend-core/core-domain/src/main/kotlin/noweekend/core/domain/jwt/JwtProviderImpl.kt
+++ b/noweekend-core/core-domain/src/main/kotlin/noweekend/core/domain/jwt/JwtProviderImpl.kt
@@ -36,7 +36,7 @@ class JwtProviderImpl(private val jwtProperties: JwtProperties) : JwtProvider {
     override fun generate(userId: String): String {
         val claims = Jwts
             .claims()
-            .setAudience(userId.toString())
+            .setAudience(userId)
             .setIssuer(jwtProperties.issuer)
 
         val now = Date()


### PR DESCRIPTION
## 요약(개요)

## 작업 내용
[//]: # (업무 체크리스트를 작성해주세요.)
- [ ] Current User Id 주입하는 Argument Resolver 생성

## 집중해서 리뷰해야 하는 부분

## 기타 전달 사항 및 참고 자료(선택)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **신규 기능**
  * 컨트롤러 메서드에서 인증된 사용자 ID를 자동으로 주입할 수 있는 `@CurrentUserId` 어노테이션이 추가되었습니다.
  * 인증 토큰이 유효하지 않을 때 발생하는 예외가 새롭게 도입되었습니다.
  * 사용자 인증 정보를 자동으로 처리하는 설정이 추가되었습니다.

* **버그 수정**
  * 에러 응답에 예외 메시지가 명확하게 포함되어 반환됩니다.

* **개선 사항**
  * 에러 메시지와 응답 생성 시 커스텀 메시지를 지정할 수 있도록 확장되었습니다.
  * 예외 및 에러 메시지 관련 클래스의 유연성이 향상되었습니다.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->