### PR TITLE
feat: Add endpoint for recommending only new tags not present in user's tag lists

### DIFF
--- a/noweekend-clients/client-mcp/src/main/kotlin/noweekend/client/mcp/recommend/RecommendApi.kt
+++ b/noweekend-clients/client-mcp/src/main/kotlin/noweekend/client/mcp/recommend/RecommendApi.kt
@@ -29,4 +29,11 @@ interface RecommendApi {
         method = [RequestMethod.POST],
     )
     fun getTag(@RequestBody request: TagRequest): ResponseEntity<List<TagResponse>>
+
+    @RequestMapping(
+        value = ["/getTagOnlyNew"], // 완전히 새로운 태그만 반환하는 엔드포인트
+        consumes = [MediaType.APPLICATION_JSON_VALUE],
+        method = [RequestMethod.POST],
+    )
+    fun getTagOnlyNew(@RequestBody request: TagRequest): ResponseEntity<List<TagResponse>>
 }

--- a/noweekend-clients/client-mcp/src/main/kotlin/noweekend/client/mcp/recommend/RecommendApi.kt
+++ b/noweekend-clients/client-mcp/src/main/kotlin/noweekend/client/mcp/recommend/RecommendApi.kt
@@ -31,7 +31,7 @@ interface RecommendApi {
     fun getTag(@RequestBody request: TagRequest): ResponseEntity<List<TagResponse>>
 
     @RequestMapping(
-        value = ["/getTagOnlyNew"], // 완전히 새로운 태그만 반환하는 엔드포인트
+        value = ["/getTagOnlyNew"],
         consumes = [MediaType.APPLICATION_JSON_VALUE],
         method = [RequestMethod.POST],
     )

--- a/noweekend-clients/client-mcp/src/main/kotlin/noweekend/client/mcp/recommend/RecommendClient.kt
+++ b/noweekend-clients/client-mcp/src/main/kotlin/noweekend/client/mcp/recommend/RecommendClient.kt
@@ -56,4 +56,32 @@ class RecommendClient(
             thirdRecommendTag = TagResponse(tagResponse[2].content),
         )
     }
+
+    fun getOnlyNewRecommend(request: UserTags): TagApiResponses? {
+        val response = try {
+            api.getTagOnlyNew(TagRequest(request))
+        } catch (e: FeignException) {
+            log.warn("[getOnlyNewRecommend] FeignException occurred. Returning null. msg=${e.message}")
+            return null
+        } catch (e: Exception) {
+            log.error("[getOnlyNewRecommend] Unexpected exception occurred. Returning null. msg=${e.message}", e)
+            return null
+        }
+
+        val tagResponse = response.body ?: run {
+            log.warn("[getOnlyNewRecommend] Response body is null. Returning null.")
+            return null
+        }
+
+        if (tagResponse.size != 3) {
+            log.warn("[getOnlyNewRecommend] Response size is not 3 (actual: ${tagResponse.size}). Returning null.")
+            return null
+        }
+
+        return TagApiResponses(
+            firstRecommendTag = TagResponse(tagResponse[0].content),
+            secondRecommendTag = TagResponse(tagResponse[1].content),
+            thirdRecommendTag = TagResponse(tagResponse[2].content),
+        )
+    }
 }

--- a/noweekend-core/core-api/src/main/kotlin/noweekend/core/api/controller/v1/RecommendController.kt
+++ b/noweekend-core/core-api/src/main/kotlin/noweekend/core/api/controller/v1/RecommendController.kt
@@ -23,12 +23,21 @@ class RecommendController(
         return ApiResponse.success(recommendService.getWeatherRecommend(userId))
     }
 
-    @GetMapping("/todo")
-    override fun getTagRecommend(
+    @GetMapping("/todo/mixed")
+    override fun getTagRecommendMixed(
         @CurrentUserId userId: String,
     ): ApiResponse<TagApiResponses> {
         return ApiResponse.success(
             recommendService.getTagRecommend(userId),
+        )
+    }
+
+    @GetMapping("/todo/new-only")
+    override fun getTagRecommendOnlyNew(
+        @CurrentUserId userId: String,
+    ): ApiResponse<TagApiResponses> {
+        return ApiResponse.success(
+            recommendService.getTagRecommendOnlyNew(userId),
         )
     }
 }

--- a/noweekend-core/core-api/src/main/kotlin/noweekend/core/api/controller/v1/docs/RecommendControllerDocs.kt
+++ b/noweekend-core/core-api/src/main/kotlin/noweekend/core/api/controller/v1/docs/RecommendControllerDocs.kt
@@ -91,7 +91,7 @@ interface RecommendControllerDocs {
     ): ApiResponse<WeatherApiResponse>
 
     @Operation(
-        summary = "유저 태그 기반 추천 태그 3개 반환",
+        summary = "유저 태그 기반으로 선택했던 것 1개와 새로운 2개의 태그, 총 3개의 태그를 반환 - 일정 추가에서 자동으로 추천",
         description = "유저가 선택한 태그를 기반으로 추천 태그 3개를 반환합니다. (추천 서비스 장애시 랜덤 3개)",
         responses = [
             SwaggerApiResponse(
@@ -148,7 +148,99 @@ interface RecommendControllerDocs {
             ),
         ],
     )
-    fun getTagRecommend(
+    fun getTagRecommendMixed(
+        @Parameter(hidden = true) @CurrentUserId userId: String,
+    ): ApiResponse<TagApiResponses>
+
+    @Operation(
+        summary = "유저 태그 기반 완전히 새로운 추천 태그 3개 반환 - 마이페이지에서 할일 수정시 사용",
+        description = """
+        유저가 선택한 태그(기존 태그)와 중복되지 않는,
+        완전히 새로운 태그 3개를 추천합니다.
+        (추천 서비스 장애 또는 태그 미입력 시 에러 반환)
+    """,
+        responses = [
+            SwaggerApiResponse(
+                responseCode = "200",
+                description = "완전히 새로운 추천 태그 3개 반환 성공",
+                content = [
+                    Content(
+                        mediaType = "application/json",
+                        schema = Schema(implementation = ApiResponse::class),
+                        examples = [
+                            ExampleObject(
+                                name = "예시 응답",
+                                value = """
+{
+  "result": "SUCCESS",
+  "data": {
+    "firstRecommendTag": { "content": "캠핑" },
+    "secondRecommendTag": { "content": "플리마켓 구경" },
+    "thirdRecommendTag": { "content": "카페 투어" }
+  },
+  "error": null
+}
+""",
+                            ),
+                        ],
+                    ),
+                ],
+            ),
+            SwaggerApiResponse(
+                responseCode = "400",
+                description = "잘못된 요청 (ex. 태그 3개 미만 등)",
+                content = [
+                    Content(
+                        mediaType = "application/json",
+                        schema = Schema(implementation = ApiResponse::class),
+                        examples = [
+                            ExampleObject(
+                                name = "태그 미입력 에러 예시",
+                                value = """
+{
+  "result": "ERROR",
+  "data": null,
+  "error": {
+    "code": "INVALID_PARAMETER",
+    "message": "사용자가 태그를 3개이상 갖고있지 않습니다. 태그를 먼저 선택해주세요.",
+    "data": {}
+  }
+}
+""",
+                            ),
+                        ],
+                    ),
+                ],
+            ),
+            SwaggerApiResponse(
+                responseCode = "404",
+                description = "추천 서버 장애로 인한 에러 (MCP 장애)",
+                content = [
+                    Content(
+                        mediaType = "application/json",
+                        schema = Schema(implementation = ApiResponse::class),
+                        examples = [
+                            ExampleObject(
+                                name = "서버 장애 에러 예시",
+                                value = """
+{
+  "result": "ERROR",
+  "data": null,
+  "error": {
+    "code": "SERVER_TAGS_ERROR",
+    "message": "MCP 추천 서버에서 장애가 발생했습니다. 새로운 태그를 추천할 수 없습니다.",
+    "data": {}
+  }
+}
+""",
+                            ),
+                        ],
+                    ),
+                ],
+            ),
+        ],
+    )
+    fun getTagRecommendOnlyNew(
         @Parameter(hidden = true) @CurrentUserId userId: String,
     ): ApiResponse<TagApiResponses>
 }

--- a/noweekend-core/core-api/src/main/kotlin/noweekend/core/domain/recommend/RecommendService.kt
+++ b/noweekend-core/core-api/src/main/kotlin/noweekend/core/domain/recommend/RecommendService.kt
@@ -6,4 +6,5 @@ import noweekend.core.api.controller.v1.response.WeatherApiResponse
 interface RecommendService {
     fun getWeatherRecommend(userId: String): WeatherApiResponse
     fun getTagRecommend(userId: String): TagApiResponses
+    fun getTagRecommendOnlyNew(userId: String): TagApiResponses
 }

--- a/noweekend-core/core-api/src/main/kotlin/noweekend/core/domain/recommend/RecommendServiceImpl.kt
+++ b/noweekend-core/core-api/src/main/kotlin/noweekend/core/domain/recommend/RecommendServiceImpl.kt
@@ -64,4 +64,29 @@ class RecommendServiceImpl(
             thirdRecommendTag = TagResponse(shuffled[2].content),
         )
     }
+
+    override fun getTagRecommendOnlyNew(userId: String): TagApiResponses {
+        val userTags = tagReader.getUserTags(userId)
+        userTagValidation(userTags)
+
+        val apiRecommendResponse = recommendClient.getOnlyNewRecommend(userTags)
+        if (apiRecommendResponse != null) {
+            val allOldTags = (
+                userTags.selectedBasicTags + userTags.unselectedBasicTags +
+                    userTags.selectedCustomTags + userTags.unselectedCustomTags
+                )
+                .map { it.content }
+                .toSet()
+
+            val allNewTags = listOf(
+                apiRecommendResponse.firstRecommendTag.content,
+                apiRecommendResponse.secondRecommendTag.content,
+                apiRecommendResponse.thirdRecommendTag.content,
+            )
+            require(allNewTags.none { it in allOldTags }) { "Returned tag already exists in user tags" }
+            return apiRecommendResponse
+        }
+
+        throw CoreException(ErrorType.SERVER_TAGS_ERROR)
+    }
 }

--- a/noweekend-core/core-api/src/main/kotlin/noweekend/core/support/error/ErrorType.kt
+++ b/noweekend-core/core-api/src/main/kotlin/noweekend/core/support/error/ErrorType.kt
@@ -13,4 +13,5 @@ enum class ErrorType(val status: HttpStatus, val code: ErrorCode, val message: S
     USER_LOCATION_NOT_FOUND(HttpStatus.NOT_FOUND, ErrorCode.E404, "사용자의 위치 정보가 존재하지 않습니다. 위치를 생성 후 요청해주세요.", LogLevel.INFO),
     INVALID_PARAMETER(HttpStatus.BAD_REQUEST, ErrorCode.E400, "잘못된 요청입니다.", LogLevel.WARN),
     USER_TAGS_ERROR(HttpStatus.BAD_REQUEST, ErrorCode.E400, "사용자의 태그가 3개 미만입니다. 초기화되지 않았습니다.", LogLevel.ERROR),
+    SERVER_TAGS_ERROR(HttpStatus.NOT_FOUND, ErrorCode.E404, "MCP 추천 서버에서 장애가 발생했습니다. 새로운 태그를 추천할 수 없습니다.", LogLevel.ERROR),
 }

--- a/noweekend-mcp/mcp-host/src/main/kotlin/noweekend/mcphost/controller/ChatbotController.kt
+++ b/noweekend-mcp/mcp-host/src/main/kotlin/noweekend/mcphost/controller/ChatbotController.kt
@@ -48,4 +48,10 @@ class ChatbotController(
         val result = chatbotService.tagRecommendation(request)
         return ResponseEntity.ok(result)
     }
+
+    @PostMapping("/getTagOnlyNew")
+    fun getTagOnlyNew(@RequestBody request: TagRequest): ResponseEntity<List<Tag>> {
+        val result = chatbotService.tagRecommendationOnlyNew(request)
+        return ResponseEntity.ok(result)
+    }
 }

--- a/noweekend-mcp/mcp-host/src/main/kotlin/noweekend/mcphost/service/ChatbotService.kt
+++ b/noweekend-mcp/mcp-host/src/main/kotlin/noweekend/mcphost/service/ChatbotService.kt
@@ -8,6 +8,7 @@ import noweekend.mcphost.controller.request.WeatherRequest
 import noweekend.mcphost.controller.response.WeatherResponse
 import noweekend.mcphost.service.Prompt.Companion.TAG_PROMPT
 import noweekend.mcphost.service.Prompt.Companion.WEATHER_PROMPT
+import org.slf4j.LoggerFactory
 import org.springframework.ai.chat.client.ChatClient
 import org.springframework.stereotype.Service
 import java.time.LocalDate
@@ -18,6 +19,8 @@ class ChatbotService(
     private val chatClient: ChatClient,
     private val objectMapper: ObjectMapper,
 ) {
+
+    private val logger = LoggerFactory.getLogger(ChatbotService::class.java)
 
     fun chat(question: String): String {
         return chatClient.prompt()
@@ -35,8 +38,7 @@ class ChatbotService(
             baseDate: $baseDate
         """.trimIndent()
 
-        // 최대 2회까지 재시도
-        repeat(2) { attempt ->
+        repeat(5) { attempt ->
             val jsonString = chatClient.prompt()
                 .system(WEATHER_PROMPT)
                 .user(userMsg)
@@ -62,7 +64,7 @@ class ChatbotService(
                 $tagJson
         """.trimIndent()
 
-        repeat(2) { attempt ->
+        repeat(5) { attempt ->
             val jsonString = chatClient.prompt()
                 .system(TAG_PROMPT)
                 .user(userMsg)
@@ -71,6 +73,38 @@ class ChatbotService(
             try {
                 if (jsonString != null) {
                     return objectMapper.readValue(jsonString)
+                }
+            } catch (e: Exception) {
+                if (attempt == 1) throw IllegalStateException("태그 추천을 받아올 수 없습니다.")
+            }
+        }
+        throw IllegalStateException("태그 추천을 받아올 수 없습니다.")
+    }
+
+    fun tagRecommendationOnlyNew(request: TagRequest): List<Tag> {
+        val tagJson = objectMapper.writeValueAsString(request.userTag)
+        val userMsg = """
+            Here is the user's tag lists in JSON:
+            $tagJson
+        """.trimIndent()
+
+        repeat(5) { attempt ->
+            val jsonString = chatClient.prompt()
+                .system(Prompt.ONLY_NEW_TAG_PROMPT)
+                .user(userMsg)
+                .call()
+                .content()
+            try {
+                logger.info("LLM tagRecommendOnlyNew raw response: $jsonString")
+
+                if (jsonString != null) {
+                    val tags: List<Tag> = objectMapper.readValue(jsonString)
+                    val allOldTags = (
+                        request.userTag.selectedBasicTags + request.userTag.unselectedBasicTags +
+                            request.userTag.selectedCustomTags + request.userTag.unselectedCustomTags
+                        ).map { it.content }.toSet()
+                    require(tags.all { it.content !in allOldTags }) { "추천 결과에 기존 태그가 포함됨" }
+                    return tags
                 }
             } catch (e: Exception) {
                 if (attempt == 1) throw IllegalStateException("태그 추천을 받아올 수 없습니다.")

--- a/noweekend-mcp/mcp-host/src/main/kotlin/noweekend/mcphost/service/Prompt.kt
+++ b/noweekend-mcp/mcp-host/src/main/kotlin/noweekend/mcphost/service/Prompt.kt
@@ -67,5 +67,35 @@ class Prompt {
             
             Below is the user's tag information:
         """.trimIndent()
+
+        val ONLY_NEW_TAG_PROMPT = """
+            You are an expert assistant for tag recommendations.
+            
+            Below is a JSON object representing the user's tag lists, all in Korean.
+            
+            **Recommendation Rules:**
+            1. Recommend exactly 3 tags as a JSON array.
+            2. All 3 tags MUST be new — they MUST NOT appear in any of the user's four tag lists.
+            3. Each tag MUST be:
+               - Culturally relevant and natural for everyday Korean life (avoid translations, use real Korean expressions).
+               - Highly similar in meaning or context to at least one of the user's *selectedBasicTags* or *selectedCustomTags*.
+               - NOT similar to any tag in *unselectedBasicTags* or *unselectedCustomTags*. Avoid tags with overlapping or close meaning to these unselected tags.
+            4. Do NOT reuse, merge, or modify any existing tag. Only suggest genuinely new, creative tags.
+            5. Each tag must be formatted as: { "content": "<tag in Korean>" }.
+            6. Respond ONLY with the JSON array. DO NOT add any explanations, markdown, comments, or extra information.
+            
+            **STRICT FORMAT — DO NOT BREAK:**
+            - Output only the JSON array (no text before or after).
+            - If you do not strictly follow these instructions, your response will be rejected.
+            
+            **Example (Return only the array, nothing else):**
+            [
+              {"content": "플리마켓 구경"},
+              {"content": "강아지 카페"},
+              {"content": "캠핑"}
+            ]
+            
+            Here is the user's tag information in JSON:
+        """.trimIndent()
     }
 }


### PR DESCRIPTION
## 요약(개요)
- 사용자가 기존에 선택/미선택한 베이식, 커스텀 태그와 겹치지 않는 **완전히 새로운 태그 3개**를 추천하는 기능을 추가했습니다.
- 프롬프트를 엄격하게 수정하여 LLM이 설명 없이 Strict JSON만 반환하도록 개선했습니다.

## 작업 내용
[//]: # (업무 체크리스트를 작성해주세요.)
- [x] MCP Host 서버에 `/getTagOnlyNew` API 추가
- [x] ChatbotService에 `tagRecommendationOnlyNew()` 메서드 구현 (Strict JSON 파싱 및 기존 태그 중복 검증 포함)
- [x] 프롬프트 내 유사 태그, 문화적 맥락 등 반영해 수정
- [x] 클라이언트 쪽 RecommendClient 및 RecommendService에 onlyNew 처리 로직 추가
- [x] 예외/에러 응답 케이스 추가 및 로그 보강

## 집중해서 리뷰해야 하는 부분
- LLM 프롬프트가 **Strict JSON only**로 응답하도록 충분히 명확하게 작성되었는지
- 기존 태그와 중복/유사하지 않은 새로운 태그 필터링 및 검증 로직
- 예외 상황 처리 및 에러 메시지 적절성

## 기타 전달 사항 및 참고 자료(선택)
- 기존 태그 추천(혼합) API와의 path 구분(기능 명확화)
- 테스트 시 LLM 응답이 JSON 외 설명을 붙이지 않도록 반복 확인 필요


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **신규 기능**
  * 사용자의 기존 태그와 겹치지 않는 완전히 새로운 태그 3개를 추천하는 "새 태그 추천" 기능이 추가되었습니다.
  * "혼합 추천" 기능의 엔드포인트가 "/todo/mixed"로 변경되었습니다.
  * 태그 추천 관련 API 및 문서가 개선되어, 추천 실패 시 명확한 에러 메시지가 제공됩니다.

* **문서**
  * Swagger 문서에 "새 태그 추천" 및 "혼합 추천" 엔드포인트가 추가되고 예시 응답이 보강되었습니다.

* **버그 수정**
  * 태그 추천 서버 장애 시 반환되는 에러 메시지가 명확하게 개선되었습니다.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->