### PR TITLE
fix: wrong apple api format

### DIFF
--- a/noweekend-clients/client-oauth/src/main/kotlin/noweekend/client/oauth/apple/AppleApi.kt
+++ b/noweekend-clients/client-oauth/src/main/kotlin/noweekend/client/oauth/apple/AppleApi.kt
@@ -1,11 +1,12 @@
 package noweekend.client.oauth.apple
 
+import feign.Headers
 import org.springframework.cloud.openfeign.FeignClient
 import org.springframework.http.MediaType
 import org.springframework.http.ResponseEntity
 import org.springframework.web.bind.annotation.GetMapping
 import org.springframework.web.bind.annotation.PostMapping
-import org.springframework.web.bind.annotation.RequestParam
+import org.springframework.web.bind.annotation.RequestBody
 
 @FeignClient(
     value = "apple-api",
@@ -21,21 +22,18 @@ internal interface AppleApi {
     @PostMapping(
         value = ["/auth/token"],
         consumes = [MediaType.APPLICATION_FORM_URLENCODED_VALUE],
+        produces = [MediaType.APPLICATION_JSON_VALUE],
     )
+    @Headers("Content-Type: application/x-www-form-urlencoded")
     fun getAccessToken(
-        @RequestParam("code") code: String,
-        @RequestParam("client_id") clientId: String,
-        @RequestParam("client_secret") clientSecret: String,
-        @RequestParam("grant_type") grantType: String,
+        @RequestBody requset: String,
     ): AppleTokens
 
     @PostMapping(
         value = ["/auth/revoke"],
         consumes = [MediaType.APPLICATION_FORM_URLENCODED_VALUE],
+        produces = [MediaType.APPLICATION_JSON_VALUE],
     )
-    fun revokeToken(
-        @RequestParam("client_id") clientId: String,
-        @RequestParam("client_secret") clientSecret: String,
-        @RequestParam("token") token: String,
-    ): ResponseEntity<Any>
+    @Headers("Content-Type: application/x-www-form-urlencoded")
+    fun revokeToken(@RequestBody request: String): ResponseEntity<Any>
 }

--- a/noweekend-clients/client-oauth/src/main/kotlin/noweekend/client/oauth/apple/AppleClient.kt
+++ b/noweekend-clients/client-oauth/src/main/kotlin/noweekend/client/oauth/apple/AppleClient.kt
@@ -16,6 +16,7 @@ import org.springframework.core.io.FileSystemResource
 import org.springframework.stereotype.Component
 import java.io.FileReader
 import java.math.BigInteger
+import java.net.URLEncoder
 import java.security.KeyFactory
 import java.security.PrivateKey
 import java.security.spec.PKCS8EncodedKeySpec
@@ -50,7 +51,13 @@ class AppleClient internal constructor(
             clientId = clientId,
             secretKeyFilePath = appleOAuthProperties.secretKeyFilePath,
         )
-        return appleApi.revokeToken(clientId, clientSecret, token).statusCode.is2xxSuccessful
+        val body = listOf(
+            "client_id" to clientId,
+            "client_secret" to clientSecret,
+            "token" to token,
+        ).joinToString("&") { "${it.first}=${URLEncoder.encode(it.second, "UTF-8")}" }
+
+        return appleApi.revokeToken(body).statusCode.is2xxSuccessful
     }
 
     private fun requestAccessToken(params: OAuthLoginParams): AppleTokens? {
@@ -61,8 +68,14 @@ class AppleClient internal constructor(
             clientId = clientId,
             secretKeyFilePath = appleOAuthProperties.secretKeyFilePath,
         )
+        val body = listOf(
+            "code" to params.getCode(),
+            "client_id" to clientId,
+            "client_secret" to clientSecret,
+            "grant_type" to AUTHORIZATION_CODE,
+        ).joinToString("&") { "${it.first}=${URLEncoder.encode(it.second, "UTF-8")}" }
 
-        return appleApi.getAccessToken(params.getCode(), clientId, clientSecret, AUTHORIZATION_CODE)
+        return appleApi.getAccessToken(body)
     }
 
     private fun makeClientSecret(keyId: String, teamId: String, clientId: String, secretKeyFilePath: String): String {


### PR DESCRIPTION
## 요약(개요)

## 작업 내용
[//]: # (업무 체크리스트를 작성해주세요.)
- [ ]

## 집중해서 리뷰해야 하는 부분

## 기타 전달 사항 및 참고 자료(선택)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **버그 수정**
  * Apple OAuth 토큰 발급 및 취소 요청 시 파라미터 전송 방식을 개선하여 요청의 신뢰성과 호환성을 높였습니다.  
  * 요청 헤더에 Content-Type이 명확하게 지정되어 응답 처리의 일관성이 향상되었습니다.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->