### PR TITLE
feat: return only current month’s holidays and unify response to use …

### DIFF
--- a/noweekend-core/core-api/src/main/kotlin/noweekend/core/api/controller/v1/HolidayController.kt
+++ b/noweekend-core/core-api/src/main/kotlin/noweekend/core/api/controller/v1/HolidayController.kt
@@ -18,7 +18,7 @@ class HolidayController(
     override fun getHolidays(): ApiResponse<HolidayResponses> {
         return ApiResponse.success(
             HolidayResponses(
-                holidayService.getThisYearHolidays(),
+                holidayService.getThisMonthHolidays(),
             ),
         )
     }

--- a/noweekend-core/core-api/src/main/kotlin/noweekend/core/api/controller/v1/docs/HolidayControllerDocs.kt
+++ b/noweekend-core/core-api/src/main/kotlin/noweekend/core/api/controller/v1/docs/HolidayControllerDocs.kt
@@ -12,14 +12,16 @@ import noweekend.core.support.response.ApiResponse
 interface HolidayControllerDocs {
 
     @Operation(
-        summary = "올해의 공휴일 목록 조회",
-        description = "해당 연도의 모든 공휴일을 조회합니다. \n" +
-            "최초 요청 시, 외부 공공데이터 API를 통해 1년치 공휴일 정보를 수집하여 DB에 저장하며, \n" +
-            "이후에는 오늘 날짜 기준 최신화된 데이터가 있으면 바로 반환합니다.",
+        summary = "이번 달의 공휴일 목록 조회",
+        description = """
+현재 월(예: 2025-07)의 공휴일을 조회합니다.  
+공휴일 데이터는 외부 API와 동기화된 DB에서 바로 조회되며,  
+API 호출 시점에는 네트워크 호출이 발생하지 않습니다.
+""",
         responses = [
             io.swagger.v3.oas.annotations.responses.ApiResponse(
                 responseCode = "200",
-                description = "공휴일 목록 조회 성공",
+                description = "이번 달 공휴일 목록 조회 성공",
                 content = [
                     Content(
                         mediaType = "application/json",
@@ -32,30 +34,15 @@ interface HolidayControllerDocs {
   "result": "SUCCESS",
   "data": {
     "holidays": [
-      {"year": 2025, "month": 1,  "day":  1, "content": "1월1일",                    "dayOfWeekKor": "WED"},
-      {"year": 2025, "month": 1,  "day": 27, "content": "임시공휴일",               "dayOfWeekKor": "MON"},
-      {"year": 2025, "month": 1,  "day": 28, "content": "설날",                 "dayOfWeekKor": "TUE"},
-      {"year": 2025, "month": 1,  "day": 29, "content": "설날",                 "dayOfWeekKor": "WED"},
-      {"year": 2025, "month": 1,  "day": 30, "content": "설날",                 "dayOfWeekKor": "THU"},
-      {"year": 2025, "month": 3,  "day":  1, "content": "삼일절",               "dayOfWeekKor": "SAT"},
-      {"year": 2025, "month": 3,  "day":  3, "content": "대체공휴일",            "dayOfWeekKor": "MON"},
-      {"year": 2025, "month": 5,  "day":  5, "content": "부처님오신날",           "dayOfWeekKor": "MON"},
-      {"year": 2025, "month": 5,  "day":  5, "content": "어린이날",             "dayOfWeekKor": "MON"},
-      {"year": 2025, "month": 5,  "day":  6, "content": "대체공휴일",            "dayOfWeekKor": "TUE"},
-      {"year": 2025, "month": 6,  "day":  3, "content": "임시공휴일(선거)",     "dayOfWeekKor": "TUE"},
-      {"year": 2025, "month": 6,  "day":  6, "content": "현충일",               "dayOfWeekKor": "FRI"},
-      {"year": 2025, "month": 8,  "day": 15, "content": "광복절",               "dayOfWeekKor": "FRI"},
-      {"year": 2025, "month":10,  "day":  3, "content": "개천절",               "dayOfWeekKor": "FRI"},
-      {"year": 2025, "month":10,  "day":  5, "content": "추석",                 "dayOfWeekKor": "SUN"},
-      {"year": 2025, "month":10,  "day":  6, "content": "추석",                 "dayOfWeekKor": "MON"},
-      {"year": 2025, "month":10,  "day":  7, "content": "추석",                 "dayOfWeekKor": "TUE"},
-      {"year": 2025, "month":10,  "day":  8, "content": "대체공휴일",            "dayOfWeekKor": "WED"},
-      {"year": 2025, "month":10,  "day":  9, "content": "한글날",               "dayOfWeekKor": "THU"},
-      {"year": 2025, "month":12,  "day": 25, "content": "기독탄신일",           "dayOfWeekKor": "THU"}
+      {
+        "date": "2025-07-17",
+        "content": "제헌절",
+        "dayOfWeekKor": "목"
+      }
     ]
   },
   "error": null
-}           
+}
 """,
                             ),
                         ],

--- a/noweekend-core/core-api/src/main/kotlin/noweekend/core/api/controller/v1/response/HolidayResponse.kt
+++ b/noweekend-core/core-api/src/main/kotlin/noweekend/core/api/controller/v1/response/HolidayResponse.kt
@@ -1,25 +1,27 @@
 package noweekend.core.api.controller.v1.response
 
+import com.fasterxml.jackson.annotation.JsonFormat
+import com.fasterxml.jackson.annotation.JsonProperty
 import noweekend.core.domain.holiday.DayOfWeekKor
 import noweekend.core.domain.holiday.Holiday
+import java.time.LocalDate
 
 data class HolidayResponse(
-    val year: Int,
-    val month: Int,
-    val day: Int,
+    @get:JsonProperty("date")
+    @get:JsonFormat(pattern = "yyyy-MM-dd")
+    val date: LocalDate,
+
     val content: String,
+
     val dayOfWeekKor: DayOfWeekKor,
 ) {
+
     companion object {
-        fun from(holiday: Holiday): HolidayResponse {
-            return HolidayResponse(
-                year = holiday.year,
-                month = holiday.month,
-                content = holiday.content,
-                day = holiday.day,
-                dayOfWeekKor = holiday.dayOfWeekKor,
-            )
-        }
+        fun from(holiday: Holiday): HolidayResponse = HolidayResponse(
+            date = LocalDate.of(holiday.year, holiday.month, holiday.day),
+            content = holiday.content,
+            dayOfWeekKor = holiday.dayOfWeekKor,
+        )
     }
 }
 

--- a/noweekend-core/core-api/src/main/kotlin/noweekend/core/domain/holiday/HolidayService.kt
+++ b/noweekend-core/core-api/src/main/kotlin/noweekend/core/domain/holiday/HolidayService.kt
@@ -3,6 +3,6 @@ package noweekend.core.domain.holiday
 import noweekend.core.api.controller.v1.response.HolidayResponse
 
 interface HolidayService {
-    fun getThisYearHolidays(): List<HolidayResponse>
     fun updateHolidays(year: Int)
+    fun getThisMonthHolidays(): List<HolidayResponse>
 }

--- a/noweekend-core/core-api/src/main/kotlin/noweekend/core/domain/holiday/HolidayServiceImpl.kt
+++ b/noweekend-core/core-api/src/main/kotlin/noweekend/core/domain/holiday/HolidayServiceImpl.kt
@@ -13,10 +13,17 @@ class HolidayServiceImpl(
     private val holidayRepository: HolidayRepository,
 ) : HolidayService {
 
-    override fun getThisYearHolidays(): List<HolidayResponse> {
-        val year = LocalDate.now().year
-        val holidays = syncHolidays(year)
-        return holidays.map { HolidayResponse.from(it) }
+    override fun getThisMonthHolidays(): List<HolidayResponse> {
+        val now = LocalDate.now()
+        val year = now.year
+        val month = now.monthValue
+
+        return holidayRepository.findAllByYear(year)
+            .asSequence()
+            .filter { it.month == month }
+            .sortedBy { it.day }
+            .map { HolidayResponse.from(it) }
+            .toList()
     }
 
     override fun updateHolidays(year: Int) {


### PR DESCRIPTION
…LocalDate

## 요약(개요)

## 작업 내용
[//]: # (업무 체크리스트를 작성해주세요.)
- [x] 공휴일 날짜 데이터 타입 LocalDate으로 변경
- [x] 이번달의 공휴일만 반환하도록 변경

## 집중해서 리뷰해야 하는 부분

## 기타 전달 사항 및 참고 자료(선택)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **신규 기능**
  * 휴일 조회 시 이번 달의 휴일만 표시됩니다.
* **리팩터**
  * 휴일 응답 형식이 연, 월, 일 대신 하나의 날짜 필드로 통합되었습니다.
* **기타**
  * 서비스 내부 동작이 연간 휴일 조회에서 월간 휴일 조회로 변경되었습니다.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->