### PR TITLE
fix: wrong apple oauth client id

### DIFF
--- a/noweekend-clients/client-oauth/src/main/resources/client-oauth.yml
+++ b/noweekend-clients/client-oauth/src/main/resources/client-oauth.yml
@@ -5,7 +5,7 @@ oauth:
     token-base-url: https://oauth2.googleapis.com
     resource-base-url: https://www.googleapis.com
   apple:
-    app-id: com.noweekend.service
+    app-id: com.noweekend.app
     key-id: 3KH8VX9ZH5
     team-id: SQ5T25W9V5
     api-url: https://appleid.apple.com


### PR DESCRIPTION
## 요약(개요)

## 작업 내용
[//]: # (업무 체크리스트를 작성해주세요.)
- [ ]

## 집중해서 리뷰해야 하는 부분

## 기타 전달 사항 및 참고 자료(선택)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Apple OAuth 클라이언트 식별자 설정이 "com.noweekend.service"에서 "com.noweekend.app"으로 변경되었습니다.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->