### PR TITLE
feat: Add DB caching and reliability improvements to weather recommendation flow

### DIFF
--- a/noweekend-clients/client-mcp/src/main/kotlin/noweekend/client/mcp/recommend/RecommendApi.kt
+++ b/noweekend-clients/client-mcp/src/main/kotlin/noweekend/client/mcp/recommend/RecommendApi.kt
@@ -5,7 +5,7 @@ import noweekend.client.mcp.recommend.model.SandwichResponse
 import noweekend.client.mcp.recommend.model.TagRequest
 import noweekend.client.mcp.recommend.model.TagResponse
 import noweekend.client.mcp.recommend.model.WeatherRequest
-import noweekend.client.mcp.recommend.model.WeatherResponse
+import noweekend.core.domain.weather.WeatherRecommendation
 import org.springframework.cloud.openfeign.FeignClient
 import org.springframework.http.MediaType
 import org.springframework.http.ResponseEntity
@@ -23,7 +23,7 @@ interface RecommendApi {
         consumes = [MediaType.APPLICATION_JSON_VALUE],
         method = [RequestMethod.POST],
     )
-    fun getFutureWeather(@RequestBody req: WeatherRequest): List<WeatherResponse>
+    fun getFutureWeather(@RequestBody req: WeatherRequest): List<WeatherRecommendation>
 
     @RequestMapping(
         value = ["/getTag"],

--- a/noweekend-clients/client-mcp/src/main/kotlin/noweekend/client/mcp/recommend/RecommendApi.kt
+++ b/noweekend-clients/client-mcp/src/main/kotlin/noweekend/client/mcp/recommend/RecommendApi.kt
@@ -23,7 +23,7 @@ interface RecommendApi {
         consumes = [MediaType.APPLICATION_JSON_VALUE],
         method = [RequestMethod.POST],
     )
-    fun getFutureWeather(@RequestBody req: WeatherRequest): ResponseEntity<List<WeatherResponse>>
+    fun getFutureWeather(@RequestBody req: WeatherRequest): List<WeatherResponse>
 
     @RequestMapping(
         value = ["/getTag"],

--- a/noweekend-clients/client-mcp/src/main/kotlin/noweekend/client/mcp/recommend/RecommendClient.kt
+++ b/noweekend-clients/client-mcp/src/main/kotlin/noweekend/client/mcp/recommend/RecommendClient.kt
@@ -21,7 +21,8 @@ class RecommendClient(
     fun getFutureWeather(request: WeatherRequest): List<WeatherResponse> {
         try {
             val response = api.getFutureWeather(request)
-            return response.body ?: emptyList()
+            log.info("response = $response")
+            return response
         } catch (e: FeignException) {
             log.warn("[getFutureWeather] FeignException occurred. Returning empty list. msg=${e.message}")
             return emptyList()

--- a/noweekend-clients/client-mcp/src/main/kotlin/noweekend/client/mcp/recommend/RecommendClient.kt
+++ b/noweekend-clients/client-mcp/src/main/kotlin/noweekend/client/mcp/recommend/RecommendClient.kt
@@ -7,8 +7,8 @@ import noweekend.client.mcp.recommend.model.TagApiResponses
 import noweekend.client.mcp.recommend.model.TagRequest
 import noweekend.client.mcp.recommend.model.TagResponse
 import noweekend.client.mcp.recommend.model.WeatherRequest
-import noweekend.client.mcp.recommend.model.WeatherResponse
 import noweekend.core.domain.tag.UserTags
+import noweekend.core.domain.weather.WeatherRecommendation
 import org.slf4j.LoggerFactory
 import org.springframework.stereotype.Component
 
@@ -18,7 +18,7 @@ class RecommendClient(
 ) {
     private val log = LoggerFactory.getLogger(this::class.java)
 
-    fun getFutureWeather(request: WeatherRequest): List<WeatherResponse> {
+    fun getFutureWeather(request: WeatherRequest): List<WeatherRecommendation> {
         try {
             val response = api.getFutureWeather(request)
             log.info("response = $response")

--- a/noweekend-clients/client-mcp/src/main/kotlin/noweekend/client/mcp/recommend/model/WeatherRequest.kt
+++ b/noweekend-clients/client-mcp/src/main/kotlin/noweekend/client/mcp/recommend/model/WeatherRequest.kt
@@ -1,13 +1,6 @@
 package noweekend.client.mcp.recommend.model
 
-import java.time.LocalDate
-
 data class WeatherRequest(
     val latitude: Double,
     val longitude: Double,
-)
-
-data class WeatherResponse(
-    val localDate: LocalDate,
-    val recommendContent: String,
 )

--- a/noweekend-clients/client-mcp/src/main/resources/client-mcp.yml
+++ b/noweekend-clients/client-mcp/src/main/resources/client-mcp.yml
@@ -20,7 +20,7 @@ spring.cloud.openfeign:
     config:
       example-api:
         connectTimeout: 2100
-        readTimeout: 5000
+        readTimeout: 120000
         loggerLevel: full
   compression:
     response:

--- a/noweekend-core/core-api/src/main/kotlin/noweekend/core/api/controller/v1/RecommendController.kt
+++ b/noweekend-core/core-api/src/main/kotlin/noweekend/core/api/controller/v1/RecommendController.kt
@@ -3,7 +3,7 @@ package noweekend.core.api.controller.v1
 import noweekend.client.mcp.recommend.model.SandwichResponse
 import noweekend.client.mcp.recommend.model.TagApiResponses
 import noweekend.core.api.controller.v1.docs.RecommendControllerDocs
-import noweekend.core.api.controller.v1.response.WeatherApiResponse
+import noweekend.core.api.controller.v1.response.WeatherResponse
 import noweekend.core.api.security.annotations.CurrentUserId
 import noweekend.core.domain.recommend.RecommendService
 import noweekend.core.support.response.ApiResponse
@@ -21,7 +21,7 @@ class RecommendController(
     @GetMapping("/weather")
     override fun getWeatherRecommend(
         @CurrentUserId userId: String,
-    ): ApiResponse<WeatherApiResponse> {
+    ): ApiResponse<WeatherResponse> {
         return ApiResponse.success(recommendService.getWeatherRecommend(userId))
     }
 

--- a/noweekend-core/core-api/src/main/kotlin/noweekend/core/api/controller/v1/docs/RecommendControllerDocs.kt
+++ b/noweekend-core/core-api/src/main/kotlin/noweekend/core/api/controller/v1/docs/RecommendControllerDocs.kt
@@ -8,7 +8,7 @@ import io.swagger.v3.oas.annotations.media.Schema
 import io.swagger.v3.oas.annotations.tags.Tag
 import noweekend.client.mcp.recommend.model.SandwichResponse
 import noweekend.client.mcp.recommend.model.TagApiResponses
-import noweekend.core.api.controller.v1.response.WeatherApiResponse
+import noweekend.core.api.controller.v1.response.WeatherResponse
 import noweekend.core.api.security.annotations.CurrentUserId
 import noweekend.core.support.response.ApiResponse
 import io.swagger.v3.oas.annotations.responses.ApiResponse as SwaggerApiResponse
@@ -40,16 +40,16 @@ interface RecommendControllerDocs {
 {
   "result": "SUCCESS",
   "data": {
-    "weatherResponses": [
-      {
-        "localDate": "2025-07-04",
-        "recommendContent": "오후에 비 와요, 연차 어때요?"
-      },
-      {
-        "localDate": "2025-07-06",
-        "recommendContent": "오전 눈 예보, 반차 추천!"
-      }
-    ]
+     "weatherResponses": [
+            {
+                "localDate": "2025-07-16",
+                "recommendContent": "08시~09시, 11시~12시, 그리고 18시~20시까지 총 4시간 동안 비가 와요. 연차 어떠세요?"
+            },
+            {
+                "localDate": "2025-07-17",
+                "recommendContent": "07시~08시, 10시~17시까지 총 8시간 동안 비가 와요. 연차 추천드려요!"
+            }
+        ]
   },
   "error": null
 }
@@ -89,7 +89,7 @@ interface RecommendControllerDocs {
     )
     fun getWeatherRecommend(
         @Parameter(hidden = true) @CurrentUserId userId: String,
-    ): ApiResponse<WeatherApiResponse>
+    ): ApiResponse<WeatherResponse>
 
     @Operation(
         summary = "유저 태그 기반으로 선택했던 것 1개와 새로운 2개의 태그, 총 3개의 태그를 반환 - 일정 추가에서 자동으로 추천",

--- a/noweekend-core/core-api/src/main/kotlin/noweekend/core/api/controller/v1/response/WeatherApiResponse.kt
+++ b/noweekend-core/core-api/src/main/kotlin/noweekend/core/api/controller/v1/response/WeatherApiResponse.kt
@@ -1,7 +1,7 @@
 package noweekend.core.api.controller.v1.response
 
-import noweekend.client.mcp.recommend.model.WeatherResponse
+import noweekend.core.domain.weather.WeatherRecommendation
 
 data class WeatherApiResponse(
-    val weatherResponses: List<WeatherResponse>,
+    val weatherRespons: List<WeatherRecommendation>,
 )

--- a/noweekend-core/core-api/src/main/kotlin/noweekend/core/api/controller/v1/response/WeatherResponse.kt
+++ b/noweekend-core/core-api/src/main/kotlin/noweekend/core/api/controller/v1/response/WeatherResponse.kt
@@ -2,6 +2,6 @@ package noweekend.core.api.controller.v1.response
 
 import noweekend.core.domain.weather.WeatherRecommendation
 
-data class WeatherApiResponse(
-    val weatherRespons: List<WeatherRecommendation>,
+data class WeatherResponse(
+    val weatherResponses: List<WeatherRecommendation>,
 )

--- a/noweekend-core/core-api/src/main/kotlin/noweekend/core/domain/recommend/RecommendService.kt
+++ b/noweekend-core/core-api/src/main/kotlin/noweekend/core/domain/recommend/RecommendService.kt
@@ -2,10 +2,10 @@ package noweekend.core.domain.recommend
 
 import noweekend.client.mcp.recommend.model.SandwichResponse
 import noweekend.client.mcp.recommend.model.TagApiResponses
-import noweekend.core.api.controller.v1.response.WeatherApiResponse
+import noweekend.core.api.controller.v1.response.WeatherResponse
 
 interface RecommendService {
-    fun getWeatherRecommend(userId: String): WeatherApiResponse
+    fun getWeatherRecommend(userId: String): WeatherResponse
     fun getTagRecommend(userId: String): TagApiResponses
     fun getTagRecommendOnlyNew(userId: String): TagApiResponses
     fun getSandwich(userId: String): SandwichResponse

--- a/noweekend-core/core-api/src/main/kotlin/noweekend/core/domain/recommend/RecommendServiceImpl.kt
+++ b/noweekend-core/core-api/src/main/kotlin/noweekend/core/domain/recommend/RecommendServiceImpl.kt
@@ -6,17 +6,18 @@ import noweekend.client.mcp.recommend.model.SandwichResponse
 import noweekend.client.mcp.recommend.model.TagApiResponses
 import noweekend.client.mcp.recommend.model.TagResponse
 import noweekend.client.mcp.recommend.model.WeatherRequest
-import noweekend.core.api.controller.v1.response.WeatherApiResponse
+import noweekend.core.api.controller.v1.response.WeatherResponse
 import noweekend.core.domain.holiday.HolidayReader
 import noweekend.core.domain.tag.TagReader
 import noweekend.core.domain.tag.UserTags
+import noweekend.core.domain.user.Location
 import noweekend.core.domain.user.UserReader
 import noweekend.core.domain.weather.WeatherReader
 import noweekend.core.domain.weather.WeatherRecommendCache
+import noweekend.core.domain.weather.WeatherRecommendation
 import noweekend.core.domain.weather.WeatherWriter
 import noweekend.core.support.error.CoreException
 import noweekend.core.support.error.ErrorType
-import org.slf4j.LoggerFactory
 import org.springframework.stereotype.Service
 import java.time.LocalDate
 import kotlin.random.Random
@@ -31,35 +32,40 @@ class RecommendServiceImpl(
     private val weatherWriter: WeatherWriter,
 ) : RecommendService {
 
-    private val log = LoggerFactory.getLogger(this::class.java)
-
-    override fun getWeatherRecommend(userId: String): WeatherApiResponse {
-        val location = userReader.findLocationByUserId(userId)
-            ?: throw CoreException(ErrorType.USER_LOCATION_NOT_FOUND)
-
+    override fun getWeatherRecommend(userId: String): WeatherResponse {
+        val location = getUserLocation(userId)
         val today = LocalDate.now()
-        // 1. 캐시에서 먼저 조회
-        val cached = weatherReader.findCacheByLocationAndDate(
+        val cached = getCachedWeather(location, today)
+        if (cached != null) {
+            return WeatherResponse(cached.weatherResponses)
+        }
+        val apiResponse = fetchWeatherFromApi(location)
+        saveWeatherCache(location, today, apiResponse)
+        return WeatherResponse(apiResponse)
+    }
+
+    private fun getUserLocation(userId: String): Location = (
+        userReader.findLocationByUserId(userId)
+            ?: throw CoreException(ErrorType.USER_LOCATION_NOT_FOUND)
+        )
+
+    private fun getCachedWeather(location: Location, today: LocalDate): WeatherRecommendCache? {
+        return weatherReader.findCacheByLocationAndDate(
             latitude = location.latitude,
             longitude = location.longitude,
             searchDate = today,
         )
-        if (cached != null) {
-            return WeatherApiResponse(cached.weatherResponses)
-        }
+    }
 
-        val apiResponse = recommendClient.getFutureWeather(
-            WeatherRequest(
-                longitude = location.longitude,
-                latitude = location.latitude,
-            ),
-        )
+    private fun fetchWeatherFromApi(location: Location): List<WeatherRecommendation> {
+        return recommendClient.getFutureWeather(WeatherRequest(location.longitude, location.latitude))
+    }
 
-        log.info("======================================== spi 호출 시작")
-        log.info("apiResponse = ${apiResponse.size}\n")
-        apiResponse.forEach { response -> log.info(response.toString() + "\n") }
-        log.info("======================================== spi 호출 종료")
-
+    private fun saveWeatherCache(
+        location: Location,
+        today: LocalDate,
+        apiResponse: List<WeatherRecommendation>,
+    ) {
         val cacheObj = WeatherRecommendCache.register(
             latitude = location.latitude,
             longitude = location.longitude,
@@ -67,8 +73,6 @@ class RecommendServiceImpl(
             weatherResponses = apiResponse,
         )
         weatherWriter.register(cacheObj)
-
-        return WeatherApiResponse(apiResponse)
     }
 
     override fun getTagRecommend(userId: String): TagApiResponses {

--- a/noweekend-core/core-api/src/main/kotlin/noweekend/core/domain/recommend/RecommendServiceImpl.kt
+++ b/noweekend-core/core-api/src/main/kotlin/noweekend/core/domain/recommend/RecommendServiceImpl.kt
@@ -11,8 +11,12 @@ import noweekend.core.domain.holiday.HolidayReader
 import noweekend.core.domain.tag.TagReader
 import noweekend.core.domain.tag.UserTags
 import noweekend.core.domain.user.UserReader
+import noweekend.core.domain.weather.WeatherReader
+import noweekend.core.domain.weather.WeatherRecommendCache
+import noweekend.core.domain.weather.WeatherWriter
 import noweekend.core.support.error.CoreException
 import noweekend.core.support.error.ErrorType
+import org.slf4j.LoggerFactory
 import org.springframework.stereotype.Service
 import java.time.LocalDate
 import kotlin.random.Random
@@ -23,20 +27,48 @@ class RecommendServiceImpl(
     private val userReader: UserReader,
     private val tagReader: TagReader,
     private val holidayReader: HolidayReader,
+    private val weatherReader: WeatherReader,
+    private val weatherWriter: WeatherWriter,
 ) : RecommendService {
 
-    override fun getWeatherRecommend(userId: String): WeatherApiResponse {
-        val location =
-            userReader.findLocationByUserId(userId) ?: throw CoreException(ErrorType.USER_LOCATION_NOT_FOUND)
+    private val log = LoggerFactory.getLogger(this::class.java)
 
-        val recommendWeathers = recommendClient.getFutureWeather(
+    override fun getWeatherRecommend(userId: String): WeatherApiResponse {
+        val location = userReader.findLocationByUserId(userId)
+            ?: throw CoreException(ErrorType.USER_LOCATION_NOT_FOUND)
+
+        val today = LocalDate.now()
+        // 1. 캐시에서 먼저 조회
+        val cached = weatherReader.findCacheByLocationAndDate(
+            latitude = location.latitude,
+            longitude = location.longitude,
+            searchDate = today,
+        )
+        if (cached != null) {
+            return WeatherApiResponse(cached.weatherResponses)
+        }
+
+        val apiResponse = recommendClient.getFutureWeather(
             WeatherRequest(
                 longitude = location.longitude,
                 latitude = location.latitude,
             ),
         )
 
-        return WeatherApiResponse(recommendWeathers)
+        log.info("======================================== spi 호출 시작")
+        log.info("apiResponse = ${apiResponse.size}\n")
+        apiResponse.forEach { response -> log.info(response.toString() + "\n") }
+        log.info("======================================== spi 호출 종료")
+
+        val cacheObj = WeatherRecommendCache.register(
+            latitude = location.latitude,
+            longitude = location.longitude,
+            searchDate = today,
+            weatherResponses = apiResponse,
+        )
+        weatherWriter.register(cacheObj)
+
+        return WeatherApiResponse(apiResponse)
     }
 
     override fun getTagRecommend(userId: String): TagApiResponses {

--- a/noweekend-core/core-domain/src/main/kotlin/noweekend/core/domain/weather/WeatherReader.kt
+++ b/noweekend-core/core-domain/src/main/kotlin/noweekend/core/domain/weather/WeatherReader.kt
@@ -1,0 +1,19 @@
+package noweekend.core.domain.weather
+
+import org.springframework.stereotype.Component
+import org.springframework.transaction.annotation.Transactional
+import java.time.LocalDate
+
+@Component
+@Transactional(readOnly = true)
+class WeatherReader(
+    private val repository: WeatherRecommendCacheRepository,
+) {
+    fun findCacheByLocationAndDate(
+        latitude: Double,
+        longitude: Double,
+        searchDate: LocalDate,
+    ): WeatherRecommendCache? {
+        return repository.findCacheByLocationAndDate(latitude, longitude, searchDate)
+    }
+}

--- a/noweekend-core/core-domain/src/main/kotlin/noweekend/core/domain/weather/WeatherRecommendCache.kt
+++ b/noweekend-core/core-domain/src/main/kotlin/noweekend/core/domain/weather/WeatherRecommendCache.kt
@@ -1,0 +1,34 @@
+package noweekend.core.domain.weather
+
+import noweekend.core.domain.util.IdGenerator
+import java.time.LocalDate
+import java.time.LocalDateTime
+
+data class WeatherRecommendCache(
+    val id: String,
+    val latitude: Double,
+    val longitude: Double,
+    val searchDate: LocalDate,
+    val weatherResponses: List<WeatherRecommendation>,
+    val createdAt: LocalDateTime?,
+    val updatedAt: LocalDateTime?,
+) {
+    companion object {
+        fun register(
+            latitude: Double,
+            longitude: Double,
+            searchDate: LocalDate,
+            weatherResponses: List<WeatherRecommendation>,
+        ): WeatherRecommendCache {
+            return WeatherRecommendCache(
+                id = IdGenerator.generate(),
+                latitude = latitude,
+                longitude = longitude,
+                searchDate = searchDate,
+                weatherResponses = weatherResponses,
+                createdAt = LocalDateTime.now(),
+                updatedAt = LocalDateTime.now(),
+            )
+        }
+    }
+}

--- a/noweekend-core/core-domain/src/main/kotlin/noweekend/core/domain/weather/WeatherRecommendCacheRepository.kt
+++ b/noweekend-core/core-domain/src/main/kotlin/noweekend/core/domain/weather/WeatherRecommendCacheRepository.kt
@@ -1,0 +1,13 @@
+package noweekend.core.domain.weather
+
+import java.time.LocalDate
+
+interface WeatherRecommendCacheRepository {
+    fun findCacheByLocationAndDate(
+        latitude: Double,
+        longitude: Double,
+        searchDate: LocalDate,
+    ): WeatherRecommendCache?
+
+    fun register(weatherRecommendCache: WeatherRecommendCache)
+}

--- a/noweekend-core/core-domain/src/main/kotlin/noweekend/core/domain/weather/WeatherRecommendation.kt
+++ b/noweekend-core/core-domain/src/main/kotlin/noweekend/core/domain/weather/WeatherRecommendation.kt
@@ -1,0 +1,8 @@
+package noweekend.core.domain.weather
+
+import java.time.LocalDate
+
+data class WeatherRecommendation(
+    val localDate: LocalDate,
+    val recommendContent: String,
+)

--- a/noweekend-core/core-domain/src/main/kotlin/noweekend/core/domain/weather/WeatherWriter.kt
+++ b/noweekend-core/core-domain/src/main/kotlin/noweekend/core/domain/weather/WeatherWriter.kt
@@ -1,0 +1,14 @@
+package noweekend.core.domain.weather
+
+import org.springframework.stereotype.Component
+import org.springframework.transaction.annotation.Transactional
+
+@Component
+@Transactional
+class WeatherWriter(
+    private val repository: WeatherRecommendCacheRepository,
+) {
+    fun register(weatherRecommendCache: WeatherRecommendCache) {
+        repository.register(weatherRecommendCache)
+    }
+}

--- a/noweekend-mcp/mcp-host/src/main/kotlin/noweekend/mcphost/controller/ChatbotController.kt
+++ b/noweekend-mcp/mcp-host/src/main/kotlin/noweekend/mcphost/controller/ChatbotController.kt
@@ -7,6 +7,7 @@ import noweekend.mcphost.controller.response.WeatherResponse
 import noweekend.mcphost.service.ChatbotService
 import noweekend.mcphost.service.GraphChatService
 import org.slf4j.LoggerFactory
+import org.springframework.http.MediaType
 import org.springframework.http.ResponseEntity
 import org.springframework.web.bind.annotation.PostMapping
 import org.springframework.web.bind.annotation.RequestBody
@@ -37,10 +38,12 @@ class ChatbotController(
             .map { ChatResponse(it) }
     }
 
-    @PostMapping("/getFutureWeather")
-    fun getFutureWeather(@RequestBody request: WeatherRequest): ResponseEntity<List<WeatherResponse>> {
-        val result = chatbotService.weatherRecommendation(request)
-        return ResponseEntity.ok(result)
+    @PostMapping(
+        "/getFutureWeather",
+        produces = [MediaType.APPLICATION_JSON_VALUE],
+    )
+    fun getFutureWeather(@RequestBody request: WeatherRequest): List<WeatherResponse> {
+        return chatbotService.weatherRecommendation(request)
     }
 
     @PostMapping("/getTag")

--- a/noweekend-mcp/mcp-host/src/main/kotlin/noweekend/mcphost/service/ChatbotService.kt
+++ b/noweekend-mcp/mcp-host/src/main/kotlin/noweekend/mcphost/service/ChatbotService.kt
@@ -33,28 +33,35 @@ class ChatbotService(
     fun weatherRecommendation(request: WeatherRequest): List<WeatherResponse> {
         val baseDate = LocalDate.now(ZoneId.of("Asia/Seoul")).toString()
         val userMsg = """
-            latitude: ${request.latitude}
-            longitude: ${request.longitude}
-            baseDate: $baseDate
+        latitude: ${request.latitude}
+        longitude: ${request.longitude}
+        baseDate: $baseDate
         """.trimIndent()
 
-        repeat(5) { attempt ->
-            val jsonString = chatClient.prompt()
-                .system(WEATHER_PROMPT)
-                .user(userMsg)
-                .call()
-                .content()
+        val backoff = listOf(1000L, 2000L, 4000L, 8000L, 16000L) // 1, 2, 4, 8, 16초 대기
+        var lastException: Exception? = null
+
+        for (attempt in backoff.indices) {
             try {
+                val jsonString = chatClient.prompt()
+                    .system(WEATHER_PROMPT)
+                    .user(userMsg)
+                    .call()
+                    .content()
                 if (jsonString != null) {
                     return objectMapper.readValue(jsonString)
                 }
             } catch (e: Exception) {
-                if (attempt == 1) {
-                    throw IllegalStateException("현재 날씨 정보를 받아올 수 없습니다.")
+                lastException = e
+                if (!e.message.orEmpty().contains("Overloaded", ignoreCase = true)) {
+                    throw IllegalStateException("현재 날씨 정보를 받아올 수 없습니다: ${e.message}", e)
+                }
+                if (attempt < backoff.lastIndex) {
+                    Thread.sleep(backoff[attempt])
                 }
             }
         }
-        throw IllegalStateException("현재 날씨 정보를 받아올 수 없습니다.")
+        throw IllegalStateException("현재 날씨 정보를 받아올 수 없습니다: ${lastException?.message}", lastException)
     }
 
     fun tagRecommendation(request: TagRequest): List<Tag> {

--- a/noweekend-mcp/mcp-host/src/main/kotlin/noweekend/mcphost/service/Prompt.kt
+++ b/noweekend-mcp/mcp-host/src/main/kotlin/noweekend/mcphost/service/Prompt.kt
@@ -3,39 +3,55 @@ package noweekend.mcphost.service
 class Prompt {
     companion object {
         val WEATHER_PROMPT = """
-            You MUST call the TOOL to get the weather data.
-            DO NOT generate, guess, or hallucinate weather data yourself.
-            ALWAYS use the TOOL OUTPUT ONLY to create your answer.
-            
-            Return your answer ONLY as a JSON array (do not wrap in markdown or add any extra explanation).
-            The JSON array must follow this structure:
-            
-            [
-              {
-                "localDate": "YYYY-MM-DD",
-                "recommendContent": "string"
-              },
-              ...
-            ]
-            
-            Rules:
-            - For each date, generate one "recommendContent" (Korean, very friendly and natural).
-            - "recommendContent" MUST clearly mention the weather situation (e.g., rain, snow, or mixed), AND be polite, soft, and friendly (not formal or stiff).
-            - "recommendContent" MUST be within 15 Korean characters. If it's longer, shorten it, but always include the weather info first.
-            - Use warm, casual, and kind expressions (e.g., "오후에 비가 온대요, 연차 어때요?", "눈 온다니 연차 써볼래요?", "종일 비예요, 오늘은 쉬어요!") 
-            - Do NOT use phrases like "권장합니다", "추천합니다".
-            - Each object must have "localDate" (YYYY-MM-DD) and "recommendContent" (max 15 Korean chars, weather included).
-            - ONLY output the JSON array, with no other explanations, markdown, or extra text.
-            
-            Follow these weather-based rules for "recommendContent":
-            - If rain or snow is predicted for 1-4 consecutive hours in the morning: include "오전" and the weather (e.g., "오전에 비가 와요, 연차 어때요?")
-            - If 1-4 hours in the afternoon: "오후에 눈 온대요, 연차 어때요?"
-            - If 4-6 hours: summarize (e.g., "비 많이 와요, 쉬는 건 어때요?")
-            - If 6+ hours or "RAIN_AND_SNOW": "종일 비예요, 오늘은 쉬어요!"
-            - Always mention the weather type (rain, snow, or mixed) at the beginning of "recommendContent".
-            - If no tool output for a day, SKIP.
-            
-            AGAIN: Respond ONLY with the above JSON array, nothing else.
+You MUST call the TOOL to get the weather data.
+DO NOT generate, guess, or hallucinate weather data yourself.
+ALWAYS use the TOOL OUTPUT ONLY to create your answer.
+
+Return your answer ONLY as a JSON array (do not wrap in markdown or add any extra explanation).
+The JSON array must follow this structure:
+
+[
+  {
+    "localDate": "YYYY-MM-DD",
+    "recommendContent": "string"
+  },
+  ...
+]
+
+Rules (STRICT. DO NOT BREAK!):
+
+1. For each date, "recommendContent" MUST meet ALL of the following:
+   - **ABSOLUTELY NEVER** use a single time (like "14시에").  
+     You MUST use a **time range** (e.g., "13시부터 17시까지") or "종일" (all day).
+   - If the precipitation is within a certain period, SPECIFY CLEARLY:  
+     "**몇시부터 몇시까지** 총 XXml 비(또는 눈/비와 눈)이 와요."
+     (e.g., "10시부터 17시까지 총 30ml 비가 와요.")
+   - If rain/snow occurs at multiple distinct times throughout the day, treat as **"종일"** (all day),  
+     and write: "**종일 총 XXml 비(또는 눈/비와 눈)이 와요."**
+   - The precipitation amount ("총 XXml") must refer to the **entire time range or the whole day**.
+
+2. ALWAYS explicitly mention the precipitation type (비, 눈, 비와 눈) and always end with a vacation suggestion ("연차" or "반차").
+
+3. EXAMPLES (you MUST follow this format):
+[
+  { "localDate": "2025-07-15", "recommendContent": "10시부터 17시까지 총 30ml 비가 와요. 연차 어때요?" },
+  { "localDate": "2025-07-16", "recommendContent": "종일 총 25ml 눈이 와요. 연차 쓰실래요?" },
+  { "localDate": "2025-07-17", "recommendContent": "11시부터 15시까지 총 15ml 비와 눈이 와요. 반차 어때요?" }
+]
+
+4. NEVER use just "14시에" or any single time. If you have only a single hour, treat it as a time **range** (e.g., "14시부터 15시까지"). **You MUST include both start and end time.**
+
+5. The answer MUST be only a JSON array as above. NO explanations, NO markdown, NO extra text.
+
+6. "recommendContent" must always be a warm, natural, and friendly sentence in Korean, and MUST have vacation suggestion ("연차" or "반차").
+
+AGAIN:  
+**ALWAYS** specify "몇시부터 몇시까지" (start time to end time), or "종일" for all-day.  
+**NEVER** use only a single time point (like "14시에"). If precipitation is for only one hour, write it as "14시부터 15시까지".
+
+Example for 1-hour rain:
+{ "localDate": "2025-07-18", "recommendContent": "14시부터 15시까지 총 10ml 비가 와요. 반차 어때요?" }
+
         """.trimIndent()
 
         val TAG_PROMPT = """

--- a/noweekend-mcp/mcp-host/src/main/kotlin/noweekend/mcphost/service/Prompt.kt
+++ b/noweekend-mcp/mcp-host/src/main/kotlin/noweekend/mcphost/service/Prompt.kt
@@ -20,37 +20,32 @@ The JSON array must follow this structure:
 
 Rules (STRICT. DO NOT BREAK!):
 
-1. For each date, "recommendContent" MUST meet ALL of the following:
-   - **ABSOLUTELY NEVER** use a single time (like "14시에").  
-     You MUST use a **time range** (e.g., "13시부터 17시까지") or "종일" (all day).
-   - If the precipitation is within a certain period, SPECIFY CLEARLY:  
-     "**몇시부터 몇시까지** 총 XXml 비(또는 눈/비와 눈)이 와요."
-     (e.g., "10시부터 17시까지 총 30ml 비가 와요.")
-   - If rain/snow occurs at multiple distinct times throughout the day, treat as **"종일"** (all day),  
-     and write: "**종일 총 XXml 비(또는 눈/비와 눈)이 와요."**
-   - The precipitation amount ("총 XXml") must refer to the **entire time range or the whole day**.
+1. For each date:
+   - Only consider the period **from 7am (07시) to 8pm (20시)**.
+   - Calculate the **total hours** when rain, snow, or both will occur within this time window.
+   - If the **total precipitation hours are less than 2**, DO NOT include this date in the array.
+   - If precipitation occurs for **2-3 hours** (inclusive), write a recommendation for **반차**.
+   - If precipitation occurs for **4 hours or more**, write a recommendation for **연차**.
+   - The "recommendContent" MUST clearly state the time range(s), total precipitation amount, precipitation type (비, 눈, 비와 눈), and finish with the vacation suggestion ("연차" or "반차").
 
-2. ALWAYS explicitly mention the precipitation type (비, 눈, 비와 눈) and always end with a vacation suggestion ("연차" or "반차").
+2. NEVER include sentences like "연차 쓰지 마세요" or "휴가를 추천하지 않습니다".  
+   If there is no recommendation, **just omit that date**.
 
-3. EXAMPLES (you MUST follow this format):
+3. All sentences in "recommendContent" must be in warm, natural Korean, following the above logic.
+
+4. For multiple separate rain/snow intervals in a day, sum all precipitation hours within 07시~20시.
+
+5. Examples:
+
 [
-  { "localDate": "2025-07-15", "recommendContent": "10시부터 17시까지 총 30ml 비가 와요. 연차 어때요?" },
+  { "localDate": "2025-07-15", "recommendContent": "10시부터 13시까지 총 20ml 비가 와요. 반차 어때요?" },
   { "localDate": "2025-07-16", "recommendContent": "종일 총 25ml 눈이 와요. 연차 쓰실래요?" },
-  { "localDate": "2025-07-17", "recommendContent": "11시부터 15시까지 총 15ml 비와 눈이 와요. 반차 어때요?" }
+  { "localDate": "2025-07-17", "recommendContent": "08시부터 18시까지 총 30ml 비와 눈이 와요. 연차 어때요?" }
 ]
 
-4. NEVER use just "14시에" or any single time. If you have only a single hour, treat it as a time **range** (e.g., "14시부터 15시까지"). **You MUST include both start and end time.**
-
-5. The answer MUST be only a JSON array as above. NO explanations, NO markdown, NO extra text.
-
-6. "recommendContent" must always be a warm, natural, and friendly sentence in Korean, and MUST have vacation suggestion ("연차" or "반차").
-
 AGAIN:  
-**ALWAYS** specify "몇시부터 몇시까지" (start time to end time), or "종일" for all-day.  
-**NEVER** use only a single time point (like "14시에"). If precipitation is for only one hour, write it as "14시부터 15시까지".
-
-Example for 1-hour rain:
-{ "localDate": "2025-07-18", "recommendContent": "14시부터 15시까지 총 10ml 비가 와요. 반차 어때요?" }
+- Only output dates where you can recommend "연차" or "반차" according to the rules above.
+- Never output a recommendation like "연차 쓰지 마세요" or "휴가를 추천하지 않습니다".
 
         """.trimIndent()
 

--- a/noweekend-mcp/mcp-host/src/main/resources/application.yml
+++ b/noweekend-mcp/mcp-host/src/main/resources/application.yml
@@ -5,7 +5,8 @@ spring:
     time-zone: Asia/Seoul
   ai:
     anthropic:
-      api-key: ENC(DSDMqqudORinUFWutrGj/hFq31Rcp+1B5SqZmhQUZKe5g5G01KIcngKwmep3K0aDGrqMIGsxlAxj9Bx9fe2MwHnpQ+pZYCT/vYAp/6hKIiuSQULyrMWgkTxd08+RWnzP9DNZb7BpX1NYuZ3dsIqPo0qVCVsyLLjc)
+#      api-key: ENC(DSDMqqudORinUFWutrGj/hFq31Rcp+1B5SqZmhQUZKe5g5G01KIcngKwmep3K0aDGrqMIGsxlAxj9Bx9fe2MwHnpQ+pZYCT/vYAp/6hKIiuSQULyrMWgkTxd08+RWnzP9DNZb7BpX1NYuZ3dsIqPo0qVCVsyLLjc)
+      api-key: ENC(q6WkPzavRozxQbgOktG6eCgCIMtfAlLQuakXP4sBXPDS+Ij8dvo9p0GJyE0+FJgEOkhys5DM50qsMOedjdZS5ewcc1ACvpRw6TcHWi7Mu158YCQUC5M4A5RGqC5ACDNnbrjrA1dmmJtEi8dNHCPlYLXRKK2m/t5Z)
       chat:
         options:
           model: claude-3-7-sonnet-20250219
@@ -19,14 +20,14 @@ spring:
           connections:
             author-tool-server:
               # prod
-              url: http://mcp-server:8081
+#              url: http://mcp-server:8081
               # local
-#              url: http://localhost:8081
+              url: http://localhost:8081
               enabled: true
         stdio:
           connections:
             brave-search:
-              command: npx
+              command: npx.cmd
               args:
                 - "-y"
                 - "@modelcontextprotocol/server-brave-search"

--- a/noweekend-storage/db-core/src/main/kotlin/noweekend/storage/db/core/weather/WeatherRecommendCacheConverter.kt
+++ b/noweekend-storage/db-core/src/main/kotlin/noweekend/storage/db/core/weather/WeatherRecommendCacheConverter.kt
@@ -1,0 +1,34 @@
+package noweekend.storage.db.core.weather
+
+import com.fasterxml.jackson.databind.ObjectMapper
+import noweekend.core.domain.weather.WeatherRecommendCache
+import noweekend.core.domain.weather.WeatherRecommendation
+import org.springframework.stereotype.Component
+
+@Component
+class WeatherRecommendCacheConverter(
+    private val objectMapper: ObjectMapper,
+) {
+    fun entityToDomain(entity: WeatherRecommendCacheEntity): WeatherRecommendCache =
+        WeatherRecommendCache(
+            id = entity.id,
+            latitude = entity.latitude,
+            longitude = entity.longitude,
+            searchDate = entity.searchDate,
+            weatherResponses = objectMapper.readValue(
+                entity.recommendJson,
+                object : com.fasterxml.jackson.core.type.TypeReference<List<WeatherRecommendation>>() {},
+            ),
+            createdAt = entity.createdAt,
+            updatedAt = entity.updatedAt,
+        )
+
+    fun domainToEntity(domain: WeatherRecommendCache): WeatherRecommendCacheEntity =
+        WeatherRecommendCacheEntity(
+            id = domain.id,
+            latitude = domain.latitude,
+            longitude = domain.longitude,
+            searchDate = domain.searchDate,
+            recommendJson = objectMapper.writeValueAsString(domain.weatherResponses),
+        )
+}

--- a/noweekend-storage/db-core/src/main/kotlin/noweekend/storage/db/core/weather/WeatherRecommendCacheEntity.kt
+++ b/noweekend-storage/db-core/src/main/kotlin/noweekend/storage/db/core/weather/WeatherRecommendCacheEntity.kt
@@ -1,0 +1,36 @@
+package noweekend.storage.db.core.weather
+
+import jakarta.persistence.Column
+import jakarta.persistence.Entity
+import jakarta.persistence.Id
+import jakarta.persistence.Table
+import jakarta.persistence.UniqueConstraint
+import noweekend.storage.db.core.BaseEntity
+import java.time.LocalDate
+
+@Entity
+@Table(
+    name = "weather_recommend_metadata",
+    uniqueConstraints = [
+        UniqueConstraint(
+            name = "uk_lat_lon_date",
+            columnNames = ["latitude", "longitude", "search_date"],
+        ),
+    ],
+)
+class WeatherRecommendCacheEntity(
+    @Id
+    val id: String,
+
+    @Column(nullable = false)
+    val latitude: Double,
+
+    @Column(nullable = false)
+    val longitude: Double,
+
+    @Column(name = "search_date", nullable = false)
+    val searchDate: LocalDate,
+
+    @Column(name = "recommend_json", columnDefinition = "TEXT")
+    val recommendJson: String,
+) : BaseEntity()

--- a/noweekend-storage/db-core/src/main/kotlin/noweekend/storage/db/core/weather/WeatherRecommendCoreRepository.kt
+++ b/noweekend-storage/db-core/src/main/kotlin/noweekend/storage/db/core/weather/WeatherRecommendCoreRepository.kt
@@ -2,6 +2,8 @@ package noweekend.storage.db.core.weather
 
 import noweekend.core.domain.weather.WeatherRecommendCache
 import noweekend.core.domain.weather.WeatherRecommendCacheRepository
+import org.slf4j.LoggerFactory
+import org.springframework.dao.DataIntegrityViolationException
 import org.springframework.stereotype.Repository
 import java.time.LocalDate
 
@@ -10,6 +12,9 @@ class WeatherRecommendCoreRepository(
     private val jpaRepository: WeatherRecommendJpaRepository,
     private val converter: WeatherRecommendCacheConverter,
 ) : WeatherRecommendCacheRepository {
+
+    private val log = LoggerFactory.getLogger(this::class.java)
+
     override fun findCacheByLocationAndDate(
         latitude: Double,
         longitude: Double,
@@ -22,9 +27,11 @@ class WeatherRecommendCoreRepository(
         )?.let { converter.entityToDomain(it) }
     }
 
-    override fun register(
-        weatherRecommendCache: WeatherRecommendCache,
-    ) {
-        jpaRepository.save(converter.domainToEntity(weatherRecommendCache))
+    override fun register(weatherRecommendCache: WeatherRecommendCache) {
+        try {
+            jpaRepository.save(converter.domainToEntity(weatherRecommendCache))
+        } catch (e: DataIntegrityViolationException) {
+            log.debug("Cache already exists for location and date", e)
+        }
     }
 }

--- a/noweekend-storage/db-core/src/main/kotlin/noweekend/storage/db/core/weather/WeatherRecommendCoreRepository.kt
+++ b/noweekend-storage/db-core/src/main/kotlin/noweekend/storage/db/core/weather/WeatherRecommendCoreRepository.kt
@@ -1,0 +1,30 @@
+package noweekend.storage.db.core.weather
+
+import noweekend.core.domain.weather.WeatherRecommendCache
+import noweekend.core.domain.weather.WeatherRecommendCacheRepository
+import org.springframework.stereotype.Repository
+import java.time.LocalDate
+
+@Repository
+class WeatherRecommendCoreRepository(
+    private val jpaRepository: WeatherRecommendJpaRepository,
+    private val converter: WeatherRecommendCacheConverter,
+) : WeatherRecommendCacheRepository {
+    override fun findCacheByLocationAndDate(
+        latitude: Double,
+        longitude: Double,
+        searchDate: LocalDate,
+    ): WeatherRecommendCache? {
+        return jpaRepository.findByLatitudeAndLongitudeAndSearchDate(
+            latitude = latitude,
+            longitude = longitude,
+            searchDate = searchDate,
+        )?.let { converter.entityToDomain(it) }
+    }
+
+    override fun register(
+        weatherRecommendCache: WeatherRecommendCache,
+    ) {
+        jpaRepository.save(converter.domainToEntity(weatherRecommendCache))
+    }
+}

--- a/noweekend-storage/db-core/src/main/kotlin/noweekend/storage/db/core/weather/WeatherRecommendJpaRepository.kt
+++ b/noweekend-storage/db-core/src/main/kotlin/noweekend/storage/db/core/weather/WeatherRecommendJpaRepository.kt
@@ -1,0 +1,12 @@
+package noweekend.storage.db.core.weather
+
+import org.springframework.data.jpa.repository.JpaRepository
+import java.time.LocalDate
+
+interface WeatherRecommendJpaRepository : JpaRepository<WeatherRecommendCacheEntity, String> {
+    fun findByLatitudeAndLongitudeAndSearchDate(
+        latitude: Double,
+        longitude: Double,
+        searchDate: LocalDate,
+    ): WeatherRecommendCacheEntity?
+}


### PR DESCRIPTION
## 요약(개요)

- 날씨 추천 결과를 DB에 캐싱하여 중복 API 호출을 방지
- LLM 프롬프트 개선(2~3시간: 반차, 4시간 이상: 연차) 및 파싱/재시도 로직 추가로 서비스 품질을 개선

## 작업 내용
- DB 기반 날씨 추천 캐싱 레이어 추가
- 백오프 및 파싱 예외처리 보강
- LLM 프롬프트 휴가 추천 기준 개선
- Recommend API/Client/DTO 구조 정비
- Antropic API Key 변경

## 집중 리뷰 포인트

- 캐시 저장/조회 동작 적합성
- 프롬프트 반영 여부와 API 재시도 처리

## 참고

- 추후 캐시 만료/정책 추가 논의 필요


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **신규 기능**
  * 날씨 추천 결과에 대한 캐시 저장 및 조회 기능이 도입되어 동일 위치·날짜에 대한 반복 요청 시 성능이 향상됩니다.

* **기능 개선**
  * 날씨 기반 휴가 추천 프롬프트 규칙이 명확하고 구체적으로 변경되어, 추천 메시지에 강수 시간대, 총 강수량, 강수 유형, 휴가 권장 문구가 포함됩니다.
  * 날씨 추천 API 응답 구조가 개선되어, 보다 일관된 데이터 포맷으로 제공됩니다.
  * 외부 API 호출 시 재시도 로직이 지수 백오프 방식으로 개선되어 안정성이 향상되었습니다.

* **버그 수정**
  * 일부 예외 상황에서 빈 리스트 반환 및 예외 메시지 로깅이 추가되어 오류 대응력이 강화되었습니다.

* **설정**
  * API 키, 외부 서비스 URL 등 일부 환경설정 값이 변경되었습니다.
  * 외부 API 호출 타임아웃이 120초로 증가하여 대기 시간이 길어졌습니다.

* **문서**
  * 날씨 추천 예시 및 반환 예시가 최신 규칙에 맞게 업데이트되었습니다.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->