### PR TITLE
feat: revoke token when deleting user

### DIFF
--- a/noweekend-core/core-api/src/main/kotlin/noweekend/core/api/controller/v1/MyPageController.kt
+++ b/noweekend-core/core-api/src/main/kotlin/noweekend/core/api/controller/v1/MyPageController.kt
@@ -6,6 +6,7 @@ import noweekend.core.api.controller.v1.request.ProfileRequest
 import noweekend.core.api.controller.v1.request.TagUpdateRequest
 import noweekend.core.api.controller.v1.response.UserInformationResponse
 import noweekend.core.api.security.annotations.CurrentUserId
+import noweekend.core.api.service.user.UserApplicationService
 import noweekend.core.domain.tag.UserTags
 import noweekend.core.domain.user.UserService
 import noweekend.core.support.response.ApiResponse
@@ -21,6 +22,7 @@ import org.springframework.web.bind.annotation.RestController
 @RequestMapping("/api/v1/user")
 class MyPageController(
     private val userService: UserService,
+    private val userApplicationService: UserApplicationService,
 ) : MyPageControllerDocs {
     @PatchMapping("/profile")
     override fun updateProfile(
@@ -77,7 +79,7 @@ class MyPageController(
     override fun deleteUser(
         @CurrentUserId userId: String,
     ): ApiResponse<String> {
-        userService.deleteUser(userId)
+        userApplicationService.deleteUser(userId)
         return ApiResponse.success(
             "회원 탈퇴가 완료되었습니다.",
         )

--- a/noweekend-core/core-api/src/main/kotlin/noweekend/core/api/service/user/UserApplicationService.kt
+++ b/noweekend-core/core-api/src/main/kotlin/noweekend/core/api/service/user/UserApplicationService.kt
@@ -27,8 +27,8 @@ class UserApplicationServiceImpl(
                 oauthClient.revokeToken(user.revocableToken!!)
             }
             userWriter.delete(userId)
-        } catch (_: NoSuchElementException) {
-            throw CoreException(ErrorType.USER_NOT_FOUND_INTERNAL)
+        } catch (_: Exception) {
+            throw CoreException(ErrorType.DEFAULT_ERROR)
         }
     }
 }

--- a/noweekend-core/core-api/src/main/kotlin/noweekend/core/api/service/user/UserApplicationService.kt
+++ b/noweekend-core/core-api/src/main/kotlin/noweekend/core/api/service/user/UserApplicationService.kt
@@ -1,0 +1,34 @@
+package noweekend.core.api.service.user
+
+import noweekend.client.oauth.common.OAuthClient
+import noweekend.client.oauth.common.Revocable
+import noweekend.core.domain.user.UserReader
+import noweekend.core.domain.user.UserWriter
+import noweekend.core.support.error.CoreException
+import noweekend.core.support.error.ErrorType
+import org.springframework.stereotype.Service
+
+interface UserApplicationService {
+    fun deleteUser(userId: String)
+}
+
+@Service
+class UserApplicationServiceImpl(
+    private val userReader: UserReader,
+    private val userWriter: UserWriter,
+    private val authClients: List<OAuthClient>,
+) : UserApplicationService {
+
+    override fun deleteUser(userId: String) {
+        try {
+            val user = userReader.findUserById(userId) ?: throw CoreException(ErrorType.USER_NOT_FOUND_INTERNAL)
+            val oauthClient = authClients.firstOrNull { client -> client.supports(user.providerType) }
+            if (oauthClient is Revocable && !user.revocableToken.isNullOrBlank()) {
+                oauthClient.revokeToken(user.revocableToken!!)
+            }
+            userWriter.delete(userId)
+        } catch (_: NoSuchElementException) {
+            throw CoreException(ErrorType.USER_NOT_FOUND_INTERNAL)
+        }
+    }
+}

--- a/noweekend-core/core-api/src/main/kotlin/noweekend/core/domain/user/UserService.kt
+++ b/noweekend-core/core-api/src/main/kotlin/noweekend/core/domain/user/UserService.kt
@@ -17,5 +17,4 @@ interface UserService {
     fun getStateTags(userId: String): UserTags
     fun updateLocation(request: LocationRequest, userId: String)
     fun getUserInformationById(userId: String): UserInformationResponse
-    fun deleteUser(userId: String)
 }

--- a/noweekend-core/core-api/src/main/kotlin/noweekend/core/domain/user/UserServiceImpl.kt
+++ b/noweekend-core/core-api/src/main/kotlin/noweekend/core/domain/user/UserServiceImpl.kt
@@ -119,12 +119,4 @@ class UserServiceImpl(
 
         return UserInformationResponse.of(user, averageTemperature)
     }
-
-    override fun deleteUser(userId: String) {
-        try {
-            userWriter.delete(userId)
-        } catch (_: NoSuchElementException) {
-            throw CoreException(ErrorType.USER_NOT_FOUND_INTERNAL)
-        }
-    }
 }


### PR DESCRIPTION
## 요약(개요)

## 작업 내용
[//]: # (업무 체크리스트를 작성해주세요.)
- [x] 탈퇴 시 애플 유저의 경우 회원 탈퇴 진행

## 집중해서 리뷰해야 하는 부분

## 기타 전달 사항 및 참고 자료(선택)
AuthClient 호출부 때문에 UserApplicationService 생성했어요. 

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **신규 기능**
  * 사용자 삭제 시 OAuth 토큰이 있을 경우 자동으로 토큰이 연동 해제됩니다.
  * 사용자 삭제 과정의 오류 처리가 개선되었습니다.

* **버그 수정**
  * 사용자 삭제 시 존재하지 않는 사용자의 경우 적절한 오류 메시지가 제공됩니다.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->