### PR TITLE
fix: store only tag content in tags_json to avoid index length issue

### DIFF
--- a/noweekend-core/core-api/src/main/kotlin/noweekend/core/domain/recommend/RecommendServiceImpl.kt
+++ b/noweekend-core/core-api/src/main/kotlin/noweekend/core/domain/recommend/RecommendServiceImpl.kt
@@ -15,6 +15,7 @@ import noweekend.core.domain.tag.TagRecommendCacheWriter
 import noweekend.core.domain.tag.TagRecommendation
 import noweekend.core.domain.tag.TagRecommendations
 import noweekend.core.domain.tag.UserTags
+import noweekend.core.domain.tag.toContentOnly
 import noweekend.core.domain.user.Location
 import noweekend.core.domain.user.UserReader
 import noweekend.core.domain.weather.WeatherReader
@@ -131,7 +132,7 @@ class RecommendServiceImpl(
     }
 
     private fun getTagRecommendCaching(tagRecommendType: RecommendType, userTags: UserTags): TagRecommendCache? {
-        val tagsJson = objectMapper.writeValueAsString(userTags)
+        val tagsJson = objectMapper.writeValueAsString(userTags.toContentOnly())
         return tagRecommendCacheReader.findTodayCache(
             recommendType = tagRecommendType,
             tagsJson = tagsJson,

--- a/noweekend-core/core-domain/src/main/kotlin/noweekend/core/domain/tag/UserTags.kt
+++ b/noweekend-core/core-domain/src/main/kotlin/noweekend/core/domain/tag/UserTags.kt
@@ -6,3 +6,13 @@ data class UserTags(
     val selectedCustomTags: List<Tag>,
     val unselectedCustomTags: List<Tag>,
 )
+
+data class ContentOnlyTag(val content: String)
+
+fun UserTags.toContentOnly(): Map<String, List<ContentOnlyTag>> =
+    mapOf(
+        "selectedBasicTags" to selectedBasicTags.map { ContentOnlyTag(it.content) },
+        "unselectedBasicTags" to unselectedBasicTags.map { ContentOnlyTag(it.content) },
+        "selectedCustomTags" to selectedCustomTags.map { ContentOnlyTag(it.content) },
+        "unselectedCustomTags" to unselectedCustomTags.map { ContentOnlyTag(it.content) },
+    )

--- a/noweekend-storage/db-core/src/main/kotlin/noweekend/storage/db/core/tag/TagRecommendCacheConverter.kt
+++ b/noweekend-storage/db-core/src/main/kotlin/noweekend/storage/db/core/tag/TagRecommendCacheConverter.kt
@@ -5,6 +5,7 @@ import com.fasterxml.jackson.databind.ObjectMapper
 import noweekend.core.domain.tag.TagRecommendCache
 import noweekend.core.domain.tag.TagRecommendations
 import noweekend.core.domain.tag.UserTags
+import noweekend.core.domain.tag.toContentOnly
 import org.springframework.stereotype.Component
 
 @Component
@@ -27,7 +28,7 @@ class TagRecommendCacheConverter(
             id = domain.id,
             recommendType = domain.recommendType,
             searchDate = domain.searchDate,
-            tagsJson = objectMapper.writeValueAsString(domain.tags),
+            tagsJson = objectMapper.writeValueAsString(domain.tags.toContentOnly()),
             recommendJson = objectMapper.writeValueAsString(domain.recommend),
         )
 }

--- a/noweekend-storage/db-core/src/main/kotlin/noweekend/storage/db/core/tag/TagRecommendCacheEntity.kt
+++ b/noweekend-storage/db-core/src/main/kotlin/noweekend/storage/db/core/tag/TagRecommendCacheEntity.kt
@@ -32,9 +32,9 @@ class TagRecommendCacheEntity(
     @Column(nullable = false)
     val searchDate: LocalDate,
 
-    @Column(nullable = false)
+    @Column(nullable = false, length = 1024)
     val tagsJson: String,
 
-    @Column(nullable = false)
+    @Column(nullable = false, length = 1024)
     val recommendJson: String,
 ) : BaseEntity()


### PR DESCRIPTION
## 요약(개요)
- `tags_json` 컬럼에 태그의 content만 저장하도록 하여 인덱스 길이 초과(Data too long for column) 문제를 해결

## 작업 내용
- `UserTags.toContentOnly()` 확장 함수 추가 (id, userId 등 제외, content만 serialization)
- 캐싱/조회 시 tags_json에 content만 저장/조회하도록 변경
- Entity의 `tagsJson`, `recommendJson` 컬럼 길이 1024로 확장

## 집중해서 리뷰해야 하는 부분
- 캐시 조회 및 저장이 의도대로 잘 동작하는지
- 기존 데이터와의 호환성

## 기타 전달 사항 및 참고 자료(선택)
- 인덱스 이슈로 인해 tags_json에 content만 저장


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **신규 기능**
  * 태그 추천 캐시 저장 시 태그의 내용만 포함된 형태로 저장하도록 개선되었습니다.

* **버그 수정**
  * 태그 추천 캐시 및 추천 결과 저장 컬럼에 1024자 길이 제한이 추가되어 데이터 저장 안정성이 향상되었습니다.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->