### PR TITLE
feat: add userId and unique index for proper cache handling

### DIFF
--- a/noweekend-core/core-api/src/main/kotlin/noweekend/core/domain/recommend/RecommendServiceImpl.kt
+++ b/noweekend-core/core-api/src/main/kotlin/noweekend/core/domain/recommend/RecommendServiceImpl.kt
@@ -116,6 +116,7 @@ class RecommendServiceImpl(
                 type = RecommendType.MIXED,
                 userTags = userTags,
                 apiResponse = apiRecommendResponse,
+                userId = userId,
             )
             return apiRecommendResponse
         }
@@ -143,12 +144,14 @@ class RecommendServiceImpl(
         type: RecommendType,
         userTags: UserTags,
         apiResponse: TagRecommendations,
+        userId: String,
     ) {
         val cache = TagRecommendCache.register(
             recommendType = type,
             searchDate = LocalDate.now(),
             tags = userTags,
             recommend = apiResponse,
+            userId = userId,
         )
         tagRecommendCacheWriter.register(cache)
     }
@@ -188,7 +191,7 @@ class RecommendServiceImpl(
                 apiRecommendResponse.thirdRecommendTag.content,
             )
             require(allNewTags.none { it in allOldTags }) { "Returned tag already exists in user tags" }
-            registerTagRecommendCache(RecommendType.ONLY_NEW, userTags, apiRecommendResponse)
+            registerTagRecommendCache(RecommendType.ONLY_NEW, userTags, apiRecommendResponse, userId)
             return apiRecommendResponse
         }
 

--- a/noweekend-core/core-domain/src/main/kotlin/noweekend/core/domain/tag/TagRecommendCache.kt
+++ b/noweekend-core/core-domain/src/main/kotlin/noweekend/core/domain/tag/TagRecommendCache.kt
@@ -12,6 +12,7 @@ data class TagRecommendCache(
     val recommend: TagRecommendations,
     val createdAt: LocalDateTime?,
     val updatedAt: LocalDateTime?,
+    val userId: String,
 ) {
     companion object {
         fun register(
@@ -19,6 +20,7 @@ data class TagRecommendCache(
             searchDate: LocalDate,
             tags: UserTags,
             recommend: TagRecommendations,
+            userId: String,
         ): TagRecommendCache {
             val now = LocalDateTime.now()
             return TagRecommendCache(
@@ -29,6 +31,7 @@ data class TagRecommendCache(
                 recommend = recommend,
                 createdAt = now,
                 updatedAt = now,
+                userId = userId,
             )
         }
     }

--- a/noweekend-storage/db-core/src/main/kotlin/noweekend/storage/db/core/tag/TagRecommendCacheConverter.kt
+++ b/noweekend-storage/db-core/src/main/kotlin/noweekend/storage/db/core/tag/TagRecommendCacheConverter.kt
@@ -20,6 +20,7 @@ class TagRecommendCacheConverter(
             recommend = objectMapper.readValue(entity.recommendJson, TagRecommendations::class.java),
             createdAt = entity.createdAt,
             updatedAt = entity.updatedAt,
+            userId = entity.userId,
         )
 
     fun domainToEntity(domain: TagRecommendCache): TagRecommendCacheEntity =
@@ -29,5 +30,6 @@ class TagRecommendCacheConverter(
             searchDate = domain.searchDate,
             tagsJson = objectMapper.writeValueAsString(domain.tags),
             recommendJson = objectMapper.writeValueAsString(domain.recommend),
+            userId = domain.userId,
         )
 }

--- a/noweekend-storage/db-core/src/main/kotlin/noweekend/storage/db/core/tag/TagRecommendCacheEntity.kt
+++ b/noweekend-storage/db-core/src/main/kotlin/noweekend/storage/db/core/tag/TagRecommendCacheEntity.kt
@@ -6,12 +6,21 @@ import jakarta.persistence.EnumType
 import jakarta.persistence.Enumerated
 import jakarta.persistence.Id
 import jakarta.persistence.Table
+import jakarta.persistence.UniqueConstraint
 import noweekend.core.domain.tag.RecommendType
 import noweekend.storage.db.core.BaseEntity
 import java.time.LocalDate
 
 @Entity
-@Table(name = "tag_recommend_metadata")
+@Table(
+    name = "tag_recommend_metadata",
+    uniqueConstraints = [
+        UniqueConstraint(
+            name = "uk_user_date_type",
+            columnNames = ["user_id", "search_date", "recommend_type"],
+        ),
+    ],
+)
 class TagRecommendCacheEntity(
     @Id
     val id: String,
@@ -23,9 +32,12 @@ class TagRecommendCacheEntity(
     @Column(nullable = false)
     val searchDate: LocalDate,
 
-    @Column(nullable = false)
+    @Column(nullable = false, length = 7000)
     val tagsJson: String,
 
-    @Column(nullable = false)
+    @Column(nullable = false, length = 5000)
     val recommendJson: String,
+
+    @Column(nullable = false)
+    val userId: String,
 ) : BaseEntity()


### PR DESCRIPTION
## 요약(개요)
- tag_recommend_metadata 테이블에 userId 컬럼을 추가하고, userId, search_date, recommend_type 3개 컬럼에 대해 복합 유니크 인덱스를 적용했습니다.

## 작업 내용
[//]: # (업무 체크리스트를 작성해주세요.)
- [x] userId 컬럼 추가
- [x] userId, search_date, recommend_type에 복합 유니크 인덱스 적용

## 집중해서 리뷰해야 하는 부분
- 유니크 인덱스 조건이 의도한 대로 동작하는지

## 기타 전달 사항 및 참고 자료(선택)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **신규 기능**
  * 태그 추천 캐시 및 관련 데이터에 사용자 ID가 포함되어 사용자별로 추천 결과가 구분됩니다.

* **버그 수정**
  * 태그 추천 캐시 테이블에 사용자 ID, 검색일, 추천 타입 조합에 대한 유니크 제약 조건이 추가되어 중복 데이터 저장이 방지됩니다.

* **기타**
  * 태그 추천 캐시 데이터의 일부 필드에 최대 길이 제한이 명확히 설정되었습니다.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->